### PR TITLE
Feat/dvot 603 automatic sdk JSDocs

### DIFF
--- a/jsdoc-to-mdx.config.json
+++ b/jsdoc-to-mdx.config.json
@@ -1,0 +1,8 @@
+{
+  "locales": [],
+  "outDir": "./docs",
+  "localesDir": "./docs/i18n/{locale}/docusaurus-plugin-content-docs/current/sdk",
+  "sidebar": "./docs",
+  "prefix": "sdk/",
+  "jsdoc": "./jsdoc.json"
+}

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,11 @@
+{
+  "tags": {
+    "allowUnknownTags" : true,
+    "dictionaries": ["jsdoc", "closure"]
+  },
+  "source": {
+    "include": ["src"],
+    "includePattern": ".+\\.(j|t)s(doc|x)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  }
+}

--- a/jsdoc2md.json
+++ b/jsdoc2md.json
@@ -1,0 +1,17 @@
+{
+  "source": {
+    "includePattern": ".+\\.ts(doc|x)?$",
+    "excludePattern": ".+\\.(test|spec).ts"
+  },
+  "plugins": [
+    "plugins/markdown",
+    "node_modules/jsdoc-babel"
+  ],
+  "babel": {
+    "extensions": ["ts", "tsx"],
+    "ignore": ["**/*.(test|spec).ts"],
+    "babelrc": false,
+    "presets": [["@babel/preset-env", { "targets": { "node": true } }], "@babel/preset-typescript"],
+    "plugins": ["@babel/proposal-class-properties", "@babel/proposal-object-rest-spread"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lintfix": "yarn lint --fix",
     "prepare": "yarn build",
     "size": "size-limit",
-    "analyze": "size-limit --why"
+    "analyze": "size-limit --why",
+    "build:doc": "jsdoc-to-mdx -c jsdoc-to-mdx.config.json"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
     }
   ],
   "devDependencies": {
+    "@babel/cli": "^7.19.3",
+    "@babel/core": "^7.20.2",
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-typescript": "^7.18.6",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "@size-limit/esbuild": "^8.1.0",
@@ -79,6 +83,9 @@
     "eslint-config-prettier": "^8.5.0",
     "husky": "^8.0.2",
     "jest": "^29.3.0",
+    "jsdoc-babel": "^0.5.0",
+    "jsdoc-to-markdown": "^7.1.1",
+    "jsdoc-to-mdx": "^1.1.2",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "size-limit": "^8.1.0",


### PR DESCRIPTION
Add necessary deps to generate mdx docs from the JSDocs on `src/`

- Configuration files
- Dependencies
- Npm script `build:doc`