### PR TITLE
DVOT-636 Replace relative links

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,9 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "npx jsdoc-to-mdx -c jsdoc-to-mdx.config.json && cp ../README.md temp_docs/sdk.md"
+    "copy-readme": "cp ../README.md temp_docs/sdk.md && sed -i 's;]: ./;]: https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' temp_docs/sdk.md",
+    "gen-docs": "npx jsdoc-to-mdx -c jsdoc-to-mdx.config.json",
+    "build": "npm run gen-docs && npm run copy-readme"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
It adds a `sed` replacement when copying the `../README.md` file into `temp_docs/sdk.md` replacing the relative links with the url of the vocdoni-sdk repository.

Example:

```diff
- [election interface]: ./src/types/election.ts#L29
+ [election interface]: https://github.com/vocdoni/vocdoni-sdk/blob/main/src/types/election.ts#L29
```