### PR TITLE
Disable 'create rnd wallet' button when census is created

### DIFF
--- a/examples/cra/src/components/Census.tsx
+++ b/examples/cra/src/components/Census.tsx
@@ -5,11 +5,12 @@ import React from 'react'
 type CensusProps = {
   account: string,
   balance: number,
+  disabled: boolean,
   signers: Wallet[],
   setSigners: React.Dispatch<React.SetStateAction<Wallet[]>>,
 }
 
-const Census = ({account, balance, signers, setSigners} : CensusProps) => (
+const Census = ({account, balance, signers, setSigners, disabled} : CensusProps) => (
   <>
     <Text>Logged in with <Code>{account}</Code> ({balance} vocdoni tokens)</Text>
     <Text>
@@ -17,6 +18,7 @@ const Census = ({account, balance, signers, setSigners} : CensusProps) => (
       some random wallets here for testing purposes:
     </Text>
     <Button
+      disabled={disabled}
       onClick={() => {
       setSigners([
         ...signers,

--- a/examples/cra/src/containers/App.tsx
+++ b/examples/cra/src/containers/App.tsx
@@ -4,7 +4,7 @@ import { Web3Provider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
 import { useEffect, useState } from 'react'
 import { Else, If, Then, When } from 'react-if'
-import { Election, EnvOptions, PlainCensus, PublishedElection, VocdoniSDKClient } from 'vocdoni-sdk';
+import { Election, EnvOptions, PlainCensus, PublishedElection, VocdoniSDKClient } from 'vocdoni-sdk'
 import Census from '../components/Census'
 import Connect from '../components/Connect'
 import Vote from '../components/VoteOptions'
@@ -91,6 +91,7 @@ export const App = () => {
                 </Then>
                 <Else>
                   <Census
+                    disabled={creating || electionId.length > 0}
                     account={account}
                     balance={balance}
                     signers={signers}


### PR DESCRIPTION
Just a minor change to the CRA example, to ensure the "Create random wallet" button is disabled once we created the election.