### PR TITLE
F/fix sdk docs inline relative links

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "copy-readme": "cp ../README.md temp_docs/sdk.md && sed -i -e 's;]: ./;]: https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' -e 's;](./;](https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' temp_docs/sdk.md",
+    "copy-readme": "cp ../README.md temp_docs/sdk.md && awk -i inplace 'match($1,/!\\[/){sub(/\\]\\(.\\//, \"](https://raw.githubusercontent.com/vocdoni/vocdoni-sdk/main/\")}1' temp_docs/sdk.md && sed -i -e 's;]: ./;]: https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' -e 's;](./;](https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' temp_docs/sdk.md",
     "gen-docs": "npx jsdoc-to-mdx -c jsdoc-to-mdx.config.json",
     "build": "npm run gen-docs && npm run copy-readme"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "copy-readme": "cp ../README.md temp_docs/sdk.md && sed -i 's;]: ./;]: https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' temp_docs/sdk.md",
+    "copy-readme": "cp ../README.md temp_docs/sdk.md && sed -i -e 's;]: ./;]: https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' -e 's;](./;](https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' temp_docs/sdk.md",
     "gen-docs": "npx jsdoc-to-mdx -c jsdoc-to-mdx.config.json",
     "build": "npm run gen-docs && npm run copy-readme"
   },


### PR DESCRIPTION
Add two scripts to fix inline links on `README.md`  when copying it. First replace image links and then the inline links if there are.

##  Fix image links

```diff
- ![Live preview](./docs/images/cra.png)
+ ![Live preview](https://raw.githubusercontent.com/vocdoni/vocdoni-sdk/main/docs/images/cra.png)
```

With the awk command:

```bash
awk -i inplace 'match($1,/!\[/){sub(/\]\(.\//, "](https://raw.githubusercontent.com/vocdoni/vocdoni-sdk/main/")}1' docs/sdk/sdk.md
```

## Fix inline relative links

```diff
- some text [link](./blah)
+ some text [link](https://github.com/vocdoni/vocdoni-sdk/blob/main/blah)
```

Using sed script, which search `](./` strings and add the github page link:

```bash
's;](./;](https://github.com/vocdoni/vocdoni-sdk/blob/main/;g' 
```