### PR TITLE
DOPS-426 docs-update workflow secret PAT updated because expired

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Checkout vocdoni-sdk repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.VOCDONIBOT_PAT }}
+        # with:
+        #   token: ${{ secrets.VOCDONIBOT_PAT }}
 
       - name: Install node
         uses: actions/setup-node@v3
@@ -43,7 +43,7 @@ jobs:
           repository: vocdoni/developer-portal
           ref: main
           path: developer-portal
-          token: ${{ secrets.VOCDONIBOT_PAT }}
+          # token: ${{ secrets.VOCDONIBOT_PAT }}
 
       - name: Copy generated docs
         run: |


### PR DESCRIPTION
* The `secrets.VOCDONIBOT_PAT` expired and that was the reason of having the error. Token was regenerated and updated.
* The `token: ${{ secrets.VOCDONIBOT_PAT }}` reference was removed in `actions/checkout` because checking out repo in same Organization is not required.