### PR TITLE
Fixes github actions

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           repository: vocdoni/developer-portal
           ref: main
+          path: developer-portal
 
       - name: Copy generated docs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['16.x']
+        node: ['18.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -34,8 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['16.x']
-        os: [self-hosted, ci1]
+        node: ['18.x']
+        os: [ci1]
 
     steps:
       # TODO: somehow reuse artifact from ubuntu-latest 'build' job?


### PR DESCRIPTION
- Properly set node 18 to some actions where was not
- Fix regression in docs generation where a `path:` arg was removed accidentally

The first fix should already be passing, you can check it on the GH action run by this PR: https://github.com/vocdoni/vocdoni-sdk/actions/runs/3987745364/jobs/6837972160

The docs issue should be fixed as soon as we accept it, since it was a required param I accidentally removed on the previous PR.