### PR TITLE
ci: spin up blind-csp using docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,11 +63,19 @@ jobs:
           docker-compose -f test/integration/util/docker-compose.yml up -d
           echo -n "voconed_hostport=" >> $GITHUB_ENV
           docker-compose -f test/integration/util/docker-compose.yml port voconed 9095 >> $GITHUB_ENV
+          echo -n "blindcsp_hostport=" >> $GITHUB_ENV
+          docker-compose -f test/integration/util/docker-compose.yml port blind-csp 5000 >> $GITHUB_ENV
 
       - name: Integration tests
         run: yarn test:integration --ci --coverage --maxWorkers=2
         env:
           API_URL: http://${{ env.voconed_hostport }}/v2
+          BLINDCSP_URL: http://${{ env.blindcsp_hostport }}/v1
+          BLINDCSP_PRIVKEY: f6e530882cde11e2050989d04c3fc523412b2fc2723c0a6155932a62ffafc2b6
+          # that privkey is hardcoded in docker-compose.yml and corresponds to:
+          # address 0xc3E925C7D971601c85eB042032F415852E56A038
+          # CSP root key 039d3ea0d911f4497903e3701b19b9c2efa2b7c3c646f3fc63d46d0a684b781b82
+          BLINDCSP_PUBKEY: 039d3ea0d911f4497903e3701b19b9c2efa2b7c3c646f3fc63d46d0a684b781b82
           FAUCET_URL: ${{ secrets.FAUCET_URL }}
           FAUCET_AUTH_TOKEN: ${{ secrets.FAUCET_AUTH_TOKEN }}
           FAUCET_TOKEN_LIMIT: 100

--- a/test/integration/csp.test.ts
+++ b/test/integration/csp.test.ts
@@ -6,8 +6,8 @@ import { CspCensus } from '../../src/types/census/csp';
 // @ts-ignore
 import { clientParams } from './util/client.params';
 
-const CSP_URL = 'https://csp-stg.vocdoni.net/v1';
-const CSP_PUBKEY = '0299f6984fddd0fab09c364d18e2759d6b728e933fae848676b8bd9700549a1817';
+const CSP_URL = process.env.BLINDCSP_URL ?? 'https://csp-stg.vocdoni.net/v1';
+const CSP_PUBKEY = process.env.BLINDCSP_PUBKEY ?? '0299f6984fddd0fab09c364d18e2759d6b728e933fae848676b8bd9700549a1817';
 
 describe('CSP tests', () => {
   it('should create an election with 10 participants and each of them should vote correctly', async () => {

--- a/test/integration/util/docker-compose.yml
+++ b/test/integration/util/docker-compose.yml
@@ -26,6 +26,24 @@ services:
       options:
         max-size: "20m"
         max-file: "10"
+  blind-csp:
+    image: "vocdoni/blind-csp:latest"
+    entrypoint: "/app/blind-csp"
+    command: |
+      --key f6e530882cde11e2050989d04c3fc523412b2fc2723c0a6155932a62ffafc2b6
+    # that's random but hardcoded so the test can create the election, it corresponds to:
+    # address 0xc3E925C7D971601c85eB042032F415852E56A038
+    # CSP root key 039d3ea0d911f4497903e3701b19b9c2efa2b7c3c646f3fc63d46d0a684b781b82
+    ports:
+      - 127.0.0.1::5000
+    sysctls:
+      net.core.somaxconn: 8128
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "10"
+
 
 volumes:
   run: {}


### PR DESCRIPTION
env var BLINDCSP_URL is passed to "yarn test" step