### PR TITLE
test/integration: use PromisePool.withConcurrency(5) instead of Promise.all

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,10 +55,10 @@ jobs:
       - name: Install deps
         run: yarn
 
-      - name: Set COMPOSE_PROJECT_NAME for voconed
+      - name: Set COMPOSE_PROJECT_NAME for voconed+blind-csp
         run: echo COMPOSE_PROJECT_NAME=${RANDOM}${RANDOM}_ci >> $GITHUB_ENV
 
-      - name: Start voconed (ephemeral vochain for integration test)
+      - name: Start voconed+blind-csp (ephemeral vochain for integration test)
         run: |
           docker-compose -f test/integration/util/docker-compose.yml up -d
           echo -n "voconed_hostport=" >> $GITHUB_ENV
@@ -80,10 +80,10 @@ jobs:
           FAUCET_AUTH_TOKEN: ${{ secrets.FAUCET_AUTH_TOKEN }}
           FAUCET_TOKEN_LIMIT: 100
 
-      - name: Debug voconed logs on failure
+      - name: Debug voconed+blind-csp logs on failure
         if: failure()
         run: docker-compose -f test/integration/util/docker-compose.yml logs
 
-      - name: Stop voconed (ephemeral vochain for integration test)
+      - name: Stop voconed+blind-csp (ephemeral vochain for integration test)
         if: success() || failure()
         run: docker-compose -f test/integration/util/docker-compose.yml down -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,9 @@ jobs:
           docker-compose -f test/integration/util/docker-compose.yml port blind-csp 5000 >> $GITHUB_ENV
 
       - name: Integration tests
-        run: yarn test:integration --ci --coverage --maxWorkers=2
+        run: yarn test:integration --ci --coverage --runInBand
+             # --runInBand makes sense in CI according to
+             # https://dev.to/vantanev/make-your-jest-tests-up-to-20-faster-by-changing-a-single-setting-i36#what-about-ci
         env:
           API_URL: http://${{ env.voconed_hostport }}/v2
           BLINDCSP_URL: http://${{ env.blindcsp_hostport }}/v1

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "@ethersproject/providers": "^5.7.1",
     "@ethersproject/signing-key": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
+    "@supercharge/promise-pool": "^2.3.2",
     "@vocdoni/proto": "1.14.0",
     "axios": "0.27.2",
     "blakejs": "^1.2.1",

--- a/test/integration/csp.test.ts
+++ b/test/integration/csp.test.ts
@@ -11,8 +11,8 @@ const CSP_URL = process.env.BLINDCSP_URL ?? 'https://csp-stg.vocdoni.net/v1';
 const CSP_PUBKEY = process.env.BLINDCSP_PUBKEY ?? '0299f6984fddd0fab09c364d18e2759d6b728e933fae848676b8bd9700549a1817';
 
 describe('CSP tests', () => {
-  it('should create an election with 10 participants and each of them should vote correctly', async () => {
-    const numVotes = 10; // should be even number
+  it('should create an election with 30 participants and each of them should vote correctly', async () => {
+    const numVotes = 30; // should be even number
     const census = new CspCensus(CSP_PUBKEY, CSP_URL);
     const participants: Wallet[] = [...new Array(numVotes)].map(() => Wallet.createRandom());
 

--- a/test/integration/util/docker-compose.yml
+++ b/test/integration/util/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     image: "vocdoni/blind-csp:latest"
     entrypoint: "/app/blind-csp"
     command: |
+      --logLevel debug
       --key f6e530882cde11e2050989d04c3fc523412b2fc2723c0a6155932a62ffafc2b6
     # that's random but hardcoded so the test can create the election, it corresponds to:
     # address 0xc3E925C7D971601c85eB042032F415852E56A038


### PR DESCRIPTION
Using Promise.all, blind-csp is overloaded and starts closing connections,
making the test fail.
With the local blind-csp this happens with as little as 10 voters.
The public remote API can handle 10 concurrent voters but not 100.
