### PR TITLE
Fix validators response list name

### DIFF
--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -163,7 +163,7 @@ export interface IChainBlockInfoResponse {
   };
 }
 
-export interface IChainValidatorsResponse {
+export interface IChainValidator {
   /**
    * Current power of the validator
    */
@@ -189,7 +189,7 @@ export interface IChainValidatorsListResponse {
   /**
    * The list of validators
    */
-  validators: Array<IChainValidatorsResponse>;
+  validators: Array<IChainValidator>;
 }
 
 export abstract class ChainAPI {

--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -189,7 +189,7 @@ export interface IChainValidatorsListResponse {
   /**
    * The list of validators
    */
-  organizations: Array<IChainValidatorsResponse>;
+  validators: Array<IChainValidatorsResponse>;
 }
 
 export abstract class ChainAPI {


### PR DESCRIPTION
- Replaced the name of the validators list (it was organizations now is validators)
- Also changed the interface name from validator object to be more descriptive