### PR TITLE
include JSON.stringify(error.response.data) of errors thrown on submit

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -85,7 +85,7 @@ export abstract class AccountAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -105,7 +105,7 @@ export abstract class AccountAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -125,7 +125,7 @@ export abstract class AccountAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -145,7 +145,7 @@ export abstract class AccountAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/census.ts
+++ b/src/api/census.ts
@@ -71,7 +71,7 @@ export abstract class CensusAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -113,7 +113,7 @@ export abstract class CensusAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -137,7 +137,7 @@ export abstract class CensusAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -157,7 +157,7 @@ export abstract class CensusAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -218,7 +218,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -242,7 +242,7 @@ export abstract class ChainAPI {
       })
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -261,7 +261,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -298,7 +298,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -317,7 +317,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -336,7 +336,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -354,7 +354,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -373,7 +373,7 @@ export abstract class ChainAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/csp.ts
+++ b/src/api/csp.ts
@@ -86,7 +86,7 @@ export abstract class CspAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -122,7 +122,7 @@ export abstract class CspAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -154,7 +154,7 @@ export abstract class CspAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/election.ts
+++ b/src/api/election.ts
@@ -344,7 +344,7 @@ export abstract class ElectionAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -363,7 +363,7 @@ export abstract class ElectionAPI {
       .then((response) => response.data.publicKeys)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -383,7 +383,7 @@ export abstract class ElectionAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -402,7 +402,7 @@ export abstract class ElectionAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -424,7 +424,7 @@ export abstract class ElectionAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/faucet.ts
+++ b/src/api/faucet.ts
@@ -36,7 +36,7 @@ export abstract class FaucetAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -30,7 +30,7 @@ export abstract class FileAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/vote.ts
+++ b/src/api/vote.ts
@@ -90,7 +90,7 @@ export abstract class VoteAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -110,7 +110,7 @@ export abstract class VoteAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });
@@ -131,7 +131,7 @@ export abstract class VoteAPI {
       .then((response) => response.status === 200)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -29,7 +29,7 @@ export abstract class WalletAPI {
       .then((response) => response.data)
       .catch((error) => {
         if (axios.isAxiosError(error)) {
-          throw new Error('Request error: ' + error.message);
+          throw new Error('Request error: ' + error.message + ', response: ' + JSON.stringify(error.response.data));
         }
         throw error;
       });


### PR DESCRIPTION
helps a lot in debugging, here's an example from today, instead of

>    Request error: Request failed with status code 500

now you get
   
>    Request error: Request failed with status code 500, response: {"error":"vochain replied with error code: (1) checkTx voteTx: no key indexes provided on vote package","code":5003}
