### PR TITLE
ci: always pull before docker-compose up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Start voconed (ephemeral vochain for integration test)
         run: |
+          docker-compose -f test/integration/util/docker-compose.yml pull -q
           docker-compose -f test/integration/util/docker-compose.yml up -d
+          docker-compose -f test/integration/util/docker-compose.yml images # check logs to see version used
           echo -n "voconed_hostport=" >> $GITHUB_ENV
           docker-compose -f test/integration/util/docker-compose.yml port voconed 9095 >> $GITHUB_ENV
           echo -n "blindcsp_hostport=" >> $GITHUB_ENV


### PR DESCRIPTION
also, include docker images version in logs

`docker-compose up` doesn't necessarily use the most recent `master` tag from docker hub. ensure pulling, otherwise the test runs with outdated binaries, hampering development.
if the image is fresh, this check takes less than a second, so almost zero impact.