### PR TITLE
Refactor `ElectionStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `ElectionStatus` includes new values `ONGOING` and `UPCOMING`. `READY` is removed an only used internally.
+
 ## [0.0.5] - 2023-03-08
 
 ### Added

--- a/src/api/election.ts
+++ b/src/api/election.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ElectionMetadata } from '../types';
+import { AllElectionStatus, ElectionMetadata, ElectionStatus } from '../types';
 
 enum ElectionAPIMethods {
   INFO = '/elections',
@@ -80,15 +80,6 @@ interface IElectionCreateResponse {
   metadataURL: number;
 }
 
-export enum ElectionStatusEnum {
-  PROCESS_UNKNOWN = 'PROCESS_UNKNOWN',
-  READY = 'READY',
-  ENDED = 'ENDED',
-  CANCELED = 'CANCELED',
-  PAUSED = 'PAUSED',
-  RESULTS = 'RESULTS',
-}
-
 export enum CensusTypeEnum {
   CENSUS_UNKNOWN = 'CENSUS_UNKNOWN',
   OFF_CHAIN_TREE = 'OFF_CHAIN_TREE',
@@ -115,7 +106,7 @@ export interface IElectionInfoResponse {
   /**
    * The status of the election
    */
-  status: ElectionStatusEnum;
+  status: Exclude<AllElectionStatus, ElectionStatus.ONGOING | ElectionStatus.UPCOMING>;
 
   /**
    * The start date of the election
@@ -352,7 +343,7 @@ export interface IElectionSummary {
   /**
    * The status of the election
    */
-  status: ElectionStatusEnum;
+  status: Exclude<AllElectionStatus, ElectionStatus.ONGOING | ElectionStatus.UPCOMING>;
 
   /**
    * The start date of the election

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import { Buffer } from 'buffer';
 import invariant from 'tiny-invariant';
 import { AccountAPI, CensusAPI, ChainAPI, ElectionAPI, FaucetAPI, FileAPI, VoteAPI, WalletAPI } from './api';
 import { AccountCore } from './core/account';
-import { ElectionCore, ElectionStatus } from './core/election';
+import { ElectionCore } from './core/election';
 import { CensusProofType, VoteCore } from './core/vote';
 import {
   Account,
@@ -19,6 +19,9 @@ import {
   Vote,
   CspVote,
   WeightedCensus,
+  ElectionStatus,
+  ElectionStatusReady,
+  AllElectionStatus,
 } from './types';
 import { delay, strip0x } from './util/common';
 import { promiseAny } from './util/promise';
@@ -26,8 +29,6 @@ import { API_URL, FAUCET_AUTH_TOKEN, FAUCET_URL, TX_WAIT_OPTIONS } from './util/
 import { isWallet } from './util/signing';
 import { CspAPI } from './api/csp';
 import { CensusBlind, getBlindedPayload } from './util/blind-signing';
-
-export { ElectionStatus };
 
 export type ChainData = {
   chainId: string;
@@ -371,7 +372,7 @@ export class VocdoniSDKClient {
             censusInfo.size,
             censusInfo.weight
           ),
-          status: ElectionCore.electionStatusFromString(electionInfo.status),
+          status: electionInfo.status,
           voteCount: electionInfo.voteCount,
           finalResults: electionInfo.finalResults,
           results: electionInfo.result,
@@ -642,7 +643,7 @@ export class VocdoniSDKClient {
    * @returns {Promise<void>}
    */
   continueElection(electionId?: string): Promise<void> {
-    return this.changeElectionStatus(electionId, ElectionStatus.READY);
+    return this.changeElectionStatus(electionId, ElectionStatusReady.READY);
   }
 
   /**
@@ -652,7 +653,7 @@ export class VocdoniSDKClient {
    * @param {ElectionStatus} newStatus The new status
    * @returns {Promise<void>}
    */
-  private changeElectionStatus(electionId: string, newStatus: ElectionStatus): Promise<void> {
+  private changeElectionStatus(electionId: string, newStatus: AllElectionStatus): Promise<void> {
     if (!this.electionId && !electionId) {
       throw Error('No election set');
     }

--- a/src/core/election.ts
+++ b/src/core/election.ts
@@ -116,7 +116,7 @@ export abstract class ElectionCore extends TransactionCore {
     };
   }
 
-  public static processStatusFromElectionStatus(status: AllElectionStatus): ProcessStatus {
+  private static processStatusFromElectionStatus(status: AllElectionStatus): ProcessStatus {
     if (status == ElectionStatus.UPCOMING || status == ElectionStatus.ONGOING) {
       return ProcessStatus.READY;
     }

--- a/src/types/election/published.ts
+++ b/src/types/election/published.ts
@@ -2,12 +2,27 @@ import { Election, IElectionParameters, IElectionType, IVoteType } from './elect
 import { MultiLanguage } from '../../util/lang';
 import { IQuestion } from '../metadata/election';
 import { PublishedCensus } from '../census/published';
-import { ElectionStatus } from '../../core/election';
+
+export enum ElectionStatus {
+  PROCESS_UNKNOWN = 'PROCESS_UNKNOWN',
+  UPCOMING = 'UPCOMING',
+  ONGOING = 'ONGOING',
+  ENDED = 'ENDED',
+  CANCELED = 'CANCELED',
+  PAUSED = 'PAUSED',
+  RESULTS = 'RESULTS',
+}
+
+export enum ElectionStatusReady {
+  READY = 'READY',
+}
+
+export type AllElectionStatus = ElectionStatus | ElectionStatusReady;
 
 export interface IPublishedElectionParameters extends IElectionParameters {
   id: string;
   organizationId: string;
-  status: ElectionStatus;
+  status: AllElectionStatus;
   voteCount: number;
   finalResults: boolean;
   results: Array<Array<string>>;
@@ -52,7 +67,14 @@ export class PublishedElection extends Election {
     });
     this._id = params.id;
     this._organizationId = params.organizationId;
-    this._status = params.status;
+    switch (params.status) {
+      case ElectionStatusReady.READY:
+        this._status = this.startDate <= new Date() ? ElectionStatus.ONGOING : ElectionStatus.UPCOMING;
+        break;
+      default:
+        this._status = params.status;
+        break;
+    }
     this._voteCount = params.voteCount;
     this._finalResults = params.finalResults;
     this._results = params.results;

--- a/test/integration/election.test.ts
+++ b/test/integration/election.test.ts
@@ -454,7 +454,7 @@ describe('Election integration tests', () => {
       })
       .then(() => client.fetchElection())
       .then((election) => {
-        expect(election.status).toEqual(ElectionStatus.ONGOING);
+        expect([ElectionStatus.ONGOING, ElectionStatus.UPCOMING]).toContain(election.status);
       });
   }, 85000);
 });

--- a/test/integration/election.test.ts
+++ b/test/integration/election.test.ts
@@ -1,8 +1,7 @@
 import { computePublicKey } from '@ethersproject/signing-key';
 import { Wallet } from '@ethersproject/wallet';
-import { Election, PlainCensus, VocdoniSDKClient, Vote, WeightedCensus } from '../../src';
+import { Election, ElectionStatus, PlainCensus, VocdoniSDKClient, Vote, WeightedCensus } from '../../src';
 import { delay } from '../../src/util/common';
-import { ElectionStatus } from '../../src/core/election';
 // @ts-ignore
 import { clientParams } from './util/client.params';
 
@@ -136,6 +135,7 @@ describe('Election integration tests', () => {
         expect(election.results[0][0]).toEqual(election.results[0][1]);
         expect(election.census.size).toEqual(numVotes);
         expect(election.census.weight).toEqual(BigInt(numVotes));
+        expect(election.status).toEqual(ElectionStatus.ONGOING);
       })
       .then(() =>
         Promise.all(
@@ -203,6 +203,7 @@ describe('Election integration tests', () => {
         expect(+election.results[0][0]).toEqual(+election.results[0][1] - numVotes / 2);
         expect(election.census.size).toEqual(numVotes);
         expect(election.census.weight).toEqual(BigInt((numVotes * (numVotes + 1)) / 2));
+        expect(election.status).toEqual(ElectionStatus.ONGOING);
       })
       .then(() =>
         Promise.all(
@@ -265,6 +266,7 @@ describe('Election integration tests', () => {
         expect(election.finalResults).toBeFalsy();
         expect(election.census.size).toEqual(numVotes);
         expect(election.census.weight).toEqual(BigInt(numVotes));
+        expect(election.status).toEqual(ElectionStatus.ONGOING);
       })
       .then(() =>
         Promise.all(
@@ -345,6 +347,7 @@ describe('Election integration tests', () => {
         expect(election.results[0][0]).toEqual(election.results[0][1]);
         expect(election.census.size).toEqual(numVotes);
         expect(election.census.weight).toEqual(BigInt(numVotes));
+        expect(election.status).toEqual(ElectionStatus.ONGOING);
       })
       .then(() =>
         Promise.all(
@@ -375,7 +378,7 @@ describe('Election integration tests', () => {
         return client.fetchElection();
       })
       .then((election) => {
-        expect(election.status).toEqual(ElectionStatus.READY);
+        expect(election.status).toEqual(ElectionStatus.UPCOMING);
         return client.endElection();
       })
       .then(() => client.fetchElection())
@@ -397,7 +400,7 @@ describe('Election integration tests', () => {
         return client.fetchElection();
       })
       .then((election) => {
-        expect(election.status).toEqual(ElectionStatus.READY);
+        expect(election.status).toEqual(ElectionStatus.UPCOMING);
         return client.pauseElection();
       })
       .then(() => client.fetchElection())
@@ -419,7 +422,7 @@ describe('Election integration tests', () => {
         return client.fetchElection();
       })
       .then((election) => {
-        expect(election.status).toEqual(ElectionStatus.READY);
+        expect(election.status).toEqual(ElectionStatus.UPCOMING);
         return client.cancelElection();
       })
       .then(() => client.fetchElection())
@@ -441,7 +444,7 @@ describe('Election integration tests', () => {
         return client.fetchElection();
       })
       .then((election) => {
-        expect(election.status).toEqual(ElectionStatus.READY);
+        expect(election.status).toEqual(ElectionStatus.UPCOMING);
         return client.pauseElection();
       })
       .then(() => client.fetchElection())
@@ -451,7 +454,7 @@ describe('Election integration tests', () => {
       })
       .then(() => client.fetchElection())
       .then((election) => {
-        expect(election.status).toEqual(ElectionStatus.READY);
+        expect(election.status).toEqual(ElectionStatus.ONGOING);
       });
   }, 85000);
 });


### PR DESCRIPTION
New values `UPCOMING` and `ONGOING`. `READY` only used internally as part of `ProcessStatus`, but not as an exported Enum for the consumer