### PR TITLE
Minor changes to issue/feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_feature.md
+++ b/.github/ISSUE_TEMPLATE/add_feature.md
@@ -6,22 +6,24 @@ labels: enhancement
 assignees: ""
 ---
 
-**Describe the feature**
-A short summary of what the feature is. Please be clear and concise.
+### Describe the feature
+<!--
+A short summary of what the bug is.
+Please be clear and concise.
+-->
 
-**Motivation**
+### Motivation
 
-**Proposal**
-In depth explanation, if required, or a clear and concise description of what the feature actually is.
+### Proposal
+<!-- In depth explanation, if required, or a clear and concise description of what the feature actually is. -->
 
-**Components affected**
+### Components affected
 
-**Constraints & Assumptions**
+### Constraints & Assumptions
+<!-- Call out any constraint and/or assumption relevant for the development and use of this feature. -->
 
-Call out any constraint and/or assumption relevant for the development and use of this feature.
-
-**Additional information (if required)**
-
+### Additional information
+<!-- Edit or remove if required -->
 - Infrastucture needed (e.g. web3 endpoint)
 - Drawbacks
 - Alternatives

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,10 +6,15 @@ labels: bug
 assignees: ""
 ---
 
-**Describe the bug**
-A short summary of what the bug is. Please be clear and concise.
+### Describe the bug
+<!--
+A short summary of what the bug is.
+Please be clear and concise.
+-->
 
-**To Reproduce (please complete the following information)**
+### To Reproduce
+
+<!-- Please complete or edit the following information -->
 
 - Config and flags
 - Steps to reproduce the behavior:
@@ -18,17 +23,18 @@ A short summary of what the bug is. Please be clear and concise.
   3. '...'
   4. See error
 
-**Current behavior**
-In depth explanation, if required, or a clear and concise description of what actually happens.
+### Current behavior
+<!-- In depth explanation, if required, or a clear and concise description of what actually happens. -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**System (please complete the following information):**
+### System:
+<!-- Please complete the following information -->
 
-- OS: [e.g. Manjaro 20.1]
-- Software version [e.g. Docker 8, Golang 1.15.1]
-- Commit hash [e.g. e84617d]
+- OS: <!-- e.g. Manjaro 20.1 -->
+- Software version: <!-- e.g. Docker 8, Golang 1.15.1 -->
+- Commit hash or tag: <!-- e.g. e84617d or 0.0.8 -->
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
Set comments and suggestions as HTML comments, so there's no need to be removing them when creating issues or features.

Edit: We could actually improve this a lot more using the [form templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms), but may be too much work for its current state