### PR TITLE
Force rollup version to 3.20.4 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jest": "^29.3.0",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
-    "rollup": "^3.9.1",
+    "rollup": "3.20.4",
     "rollup-plugin-dts": "^5.1.1",
     "rollup-plugin-esbuild": "^5.0.0",
     "size-limit": "^8.1.0",


### PR DESCRIPTION
Closes #141 (for now).

The issue is with rollup 3.20.5, see: https://github.com/rollup/rollup/issues/4945

I'm opening a new issue to keep track of this fixed version, and to unlock it once the upstream issue is fixed.