### PR TITLE
Fix gif url

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ You can find a [full featured CRA][example-cra] application with all the previou
 steps in the [examples] folder. In that folder you'll also find a
 [es modules example][example-esm], creating and voting an election process.
 
-![example-esm demo]
+![example-esm demo](./examples/esm/esm.gif)
 
 ## Docs
 
@@ -551,7 +551,6 @@ This SDK is licensed under the [GNU Affero General Public License v3.0][license]
 [examples]: ./examples
 [example-cra]: ./examples/cra
 [example-esm]: ./examples/esm
-[example-esm demo]: ./examples/esm/esm.gif
 [license]: ./LICENSE
 [devportal]: https://developer.vocdoni.io/sdk
 [builddocs]: ./docs/README.md


### PR DESCRIPTION
When README is imported to developer portal, the relative urls are fixed to point to the git repository using `awk` and `sed` scripts.

For the images it point to the raw.github.com url, but the url of the image have to be just after the image declaration on the markdown

```
![txt](./relative/path.jpg)
```

However, for the ESM example gif, the format was different, causing that the fixed link doesn't point to the `raw.` url. It was:

```
![text]
//...

[text]: ./relative/path.jpg
``` 

So it causes that replaced url is to `github.com` causing image break on the developer portal.