### PR TITLE
New util areEqualHexStrings + exported everything from utils/common

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client';
 export * from './types';
 export * from './api';
+export * from './util/common';

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -22,3 +22,17 @@ export function getHex(): string {
   const bytes = getBytes(32);
   return keccak256(bytes);
 }
+
+/**
+ * Compares two hex strings checking if they're the same. It ensures both
+ * have hex prefix and are lowercase.
+ *
+ * @param {string} hex1
+ * @param {string} hex2
+ * @returns {boolean}
+ */
+export function areEqualHexStrings(hex1?: string, hex2?: string) {
+  if (!hex1 || !hex2) return false;
+
+  return ensure0x(hex1.toLowerCase()) === ensure0x(hex2.toLowerCase());
+}


### PR DESCRIPTION
Added new util `areEqualHexStrings`, that just compares two strings to check if they are the same hex string/address.

The `utils/common` file has been exported entirely, since this util resides there, but also because some other utils in that file can be useful (the ensure0x and strip0x are quite common and we repeated those in almost every project).