### PR TITLE
Add explorerUrl client property

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,7 @@ import {
   WeightedCensus,
 } from './types';
 import { delay } from './util/common';
-import { API_URL, FAUCET_AUTH_TOKEN, FAUCET_URL, TX_WAIT_OPTIONS } from './util/constants';
+import { API_URL, EXPLORER_URL, FAUCET_AUTH_TOKEN, FAUCET_URL, TX_WAIT_OPTIONS } from './util/constants';
 import { CspAPI } from './api/csp';
 import { CensusBlind, getBlindedPayload } from './util/blind-signing';
 
@@ -162,6 +162,7 @@ export class VocdoniSDKClient {
   public url: string;
   public wallet: Wallet | Signer | null;
   public electionId: string | null;
+  public explorerUrl: string;
   public faucet: FaucetOptions | null;
   public tx_wait: TxWaitOptions | null;
 
@@ -191,6 +192,7 @@ export class VocdoniSDKClient {
       retry_time: opts.tx_wait?.retry_time ?? TX_WAIT_OPTIONS.retry_time,
       attempts: opts.tx_wait?.attempts ?? TX_WAIT_OPTIONS.attempts,
     };
+    this.explorerUrl = EXPLORER_URL[opts.env];
   }
 
   /**

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -4,6 +4,12 @@ export const API_URL = {
   prod: 'https://api.vocdoni.net/v2',
 };
 
+export const EXPLORER_URL = {
+  dev: 'https://dev.explorer.vote',
+  stg: 'https://stg.explorer.vote',
+  prod: 'https://explorer.vote',
+};
+
 export const FAUCET_URL = {
   dev: 'https://faucet-azeno.vocdoni.net/faucet/vocdoni/dev',
   stg: 'https://faucet-azeno.vocdoni.net/faucet/vocdoni/stage',


### PR DESCRIPTION
I'm not really convinced about this implementation... but I think it's because I wanted to create a getter method, which I can't since I need to access the environment, and this is not stored in the client instance, so the only way I could think of was by adding a new property in the constructor.

Let me know if you'd change anything