### PR TITLE
Add txInfo

### DIFF
--- a/src/api/chain/transactions.ts
+++ b/src/api/chain/transactions.ts
@@ -1,3 +1,5 @@
+import { IChainTxReference } from '../chain';
+
 export interface Tx {
   payload?:
     | {
@@ -48,6 +50,7 @@ export interface Tx {
   //     $case: 'setKeykeeper';
   //     collectFaucet: SetKeyKeeperTx;
   //   };
+  txInfo: IChainTxReference;
 }
 
 export interface VoteEnvelope {


### PR DESCRIPTION
Added `txInfo` to `Tx` interface.

Related to https://github.com/vocdoni/interoperability/issues/40

This caused a bug that the tx is not decoded backend side, see https://github.com/vocdoni/vocdoni-node/issues/956