### PR TITLE
ci: docker image vocdoni/go-dvote:master is now vocdoni/vocdoni-node:main

### DIFF
--- a/test/integration/util/docker-compose.yml
+++ b/test/integration/util/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3.4"
 
 services:
   voconed:
-    # pull master tag (instead of latest) to ensure we're testing against bleeding edge
-    image: "vocdoni/go-dvote:master"
+    # pull main tag (instead of latest) to ensure we're testing against bleeding edge
+    image: "vocdoni/vocdoni-node:main"
     entrypoint: "/app/voconed"
     env_file: voconed.env
     # TODO: the following flags should really go into voconed.env


### PR DESCRIPTION
sorry for not noticing this before

i'm also already pointing to `main` tag instead of `master` (both tags are synced right now but soon `master` will be left behind, so i'm already avoiding another future issue)