### PR TITLE
Add missing attribute

### DIFF
--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -198,6 +198,7 @@ export interface IChainBlockInfoResponse {
   evidence: {
     evidence: Array<string>;
   };
+  hash: string;
   header: {
     appHash: string;
     chainId: string;

--- a/src/api/chain/transactions.ts
+++ b/src/api/chain/transactions.ts
@@ -1,7 +1,7 @@
 import { IChainTxReference } from '../chain';
 
 export interface Tx {
-  payload?:
+  tx?:
     | {
         $case: 'vote';
         vote: VoteEnvelope;


### PR DESCRIPTION
Add mising attribute on block interface (`hash`):

```bash
curl https://api-dev.vocdoni.net/v2/chain/blocks/2 -s | jq
```