### PR TITLE
Fix API interfaces and methods

### DIFF
--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -16,6 +16,7 @@ enum ChainAPIMethods {
   VALIDATORS_LIST = '/chain/validators',
   BLOCK_INFO = '/chain/blocks',
   BLOCK_INFO_BY_HASH = '/chain/blocks/hash',
+  DATE_TO_BLOCK = '/chain/dateToBlock/{timestamp}',
 }
 
 export interface IChainGetInfoResponse {
@@ -231,6 +232,10 @@ export interface IChainBlockInfoResponse {
   };
 }
 
+interface IBlockToDateResponse {
+  height: number;
+}
+
 export interface IChainValidator {
   /**
    * Current power of the validator
@@ -426,6 +431,18 @@ export abstract class ChainAPI extends API {
   public static blockByHash(url: string, hash: string): Promise<IChainBlockInfoResponse> {
     return axios
       .get<IChainBlockInfoResponse>(url + ChainAPIMethods.BLOCK_INFO_BY_HASH + '/' + hash)
+      .then((response) => response.data)
+      .catch(this.isApiError);
+  }
+
+  /**
+   * By a given date give the estimate block for the current Vochain.
+   * @param url API URL
+   * @param timeStamp unix format timestamp
+   */
+  public static dateToBlock(url: string, timeStamp: number): Promise<IBlockToDateResponse> {
+    return axios
+      .get<IBlockToDateResponse>(url + ChainAPIMethods.DATE_TO_BLOCK.replace('{timestamp}', String(timeStamp)))
       .then((response) => response.data)
       .catch(this.isApiError);
   }

--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -482,6 +482,7 @@ export abstract class ChainAPI extends API {
    *
    * @param url API URL
    * @param height block height to calculate approximate timestamp
+   * @return {Promise<IBlockToDateResponse>}
    */
   public static blockToDate(url: string, height: number): Promise<IBlockToDateResponse> {
     return axios

--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -18,6 +18,7 @@ enum ChainAPIMethods {
   BLOCK_INFO_BY_HASH = '/chain/blocks/hash',
   BLOCK_TRANSACTIONS = '/chain/blocks/{height}/transactions/page/{page}',
   DATE_TO_BLOCK = '/chain/dateToBlock/{timestamp}',
+  BLOCK_TO_DATE = '/chain/blockToDate/{height}',
 }
 
 export interface IChainGetInfoResponse {
@@ -239,8 +240,12 @@ export interface IBlockTransactionsResponse {
   transactions: Array<IChainTxReference>;
 }
 
-interface IBlockToDateResponse {
+interface IDateToBlockResponse {
   height: number;
+}
+
+interface IBlockToDateResponse {
+  date: string;
 }
 
 export interface IChainValidator {
@@ -463,10 +468,24 @@ export abstract class ChainAPI extends API {
    * By a given date give the estimate block for the current Vochain.
    * @param url API URL
    * @param timeStamp unix format timestamp
+   * @returns {Promise<IDateToBlockResponse>}
    */
-  public static dateToBlock(url: string, timeStamp: number): Promise<IBlockToDateResponse> {
+  public static dateToBlock(url: string, timeStamp: number): Promise<IDateToBlockResponse> {
     return axios
-      .get<IBlockToDateResponse>(url + ChainAPIMethods.DATE_TO_BLOCK.replace('{timestamp}', String(timeStamp)))
+      .get<IDateToBlockResponse>(url + ChainAPIMethods.DATE_TO_BLOCK.replace('{timestamp}', String(timeStamp)))
+      .then((response) => response.data)
+      .catch(this.isApiError);
+  }
+
+  /**
+   * Return approximate date by a given block height.
+   *
+   * @param url API URL
+   * @param height block height to calculate approximate timestamp
+   */
+  public static blockToDate(url: string, height: number): Promise<IBlockToDateResponse> {
+    return axios
+      .get<IBlockToDateResponse>(url + ChainAPIMethods.BLOCK_TO_DATE.replace('{height}', String(height)))
       .then((response) => response.data)
       .catch(this.isApiError);
   }

--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -455,7 +455,7 @@ export abstract class ChainAPI extends API {
    * @param {number} page the page number
    * @returns {Promise<IBlockTransactionsResponse>}
    */
-  public static blockTransactions(url: string, height: number, page: number): Promise<IBlockTransactionsResponse> {
+  public static blockTransactions(url: string, height: number, page: number = 0): Promise<IBlockTransactionsResponse> {
     return axios
       .get<IBlockTransactionsResponse>(
         url + ChainAPIMethods.BLOCK_TRANSACTIONS.replace('{height}', String(height)).replace('{page}', String(page))

--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -16,6 +16,7 @@ enum ChainAPIMethods {
   VALIDATORS_LIST = '/chain/validators',
   BLOCK_INFO = '/chain/blocks',
   BLOCK_INFO_BY_HASH = '/chain/blocks/hash',
+  BLOCK_TRANSACTIONS = '/chain/blocks/{height}/transactions/page/{page}',
   DATE_TO_BLOCK = '/chain/dateToBlock/{timestamp}',
 }
 
@@ -232,6 +233,12 @@ export interface IChainBlockInfoResponse {
   };
 }
 
+export interface IBlockTransactionsResponse {
+  blockNumber: number;
+  transactionCount: number;
+  transactions: Array<IChainTxReference>;
+}
+
 interface IBlockToDateResponse {
   height: number;
 }
@@ -431,6 +438,23 @@ export abstract class ChainAPI extends API {
   public static blockByHash(url: string, hash: string): Promise<IChainBlockInfoResponse> {
     return axios
       .get<IChainBlockInfoResponse>(url + ChainAPIMethods.BLOCK_INFO_BY_HASH + '/' + hash)
+      .then((response) => response.data)
+      .catch(this.isApiError);
+  }
+
+  /**
+   * Get paginated list of transactions registered on specific block
+   *
+   * @param {string} url API endpoint URL
+   * @param {number} height block height
+   * @param {number} page the page number
+   * @returns {Promise<IBlockTransactionsResponse>}
+   */
+  public static blockTransactions(url: string, height: number, page: number): Promise<IBlockTransactionsResponse> {
+    return axios
+      .get<IBlockTransactionsResponse>(
+        url + ChainAPIMethods.BLOCK_TRANSACTIONS.replace('{height}', String(height)).replace('{page}', String(page))
+      )
       .then((response) => response.data)
       .catch(this.isApiError);
   }

--- a/src/api/election.ts
+++ b/src/api/election.ts
@@ -271,7 +271,7 @@ export interface IElectionInfoResponse {
   metadata: ElectionMetadata;
 }
 
-interface IEncryptionPublicKey {
+export interface IEncryptionKey {
   /**
    * The index of the encryption key
    */
@@ -283,11 +283,9 @@ interface IEncryptionPublicKey {
   key: string;
 }
 
-interface IElectionKeysResponse {
-  /**
-   * The hash of the transaction
-   */
-  publicKeys: IEncryptionPublicKey[];
+export interface IElectionKeysResponse {
+  publicKeys: IEncryptionKey[];
+  privateKeys: IEncryptionKey[];
 }
 
 interface IElectionVotesCountResponse {
@@ -409,12 +407,12 @@ export abstract class ElectionAPI extends API {
    *
    * @param {string} url API endpoint URL
    * @param {string} electionId The identifier of the election
-   * @returns {Promise<Array<IEncryptionPublicKey>>}
+   * @returns {Promise<IElectionKeysResponse>}
    */
-  public static keys(url: string, electionId: string): Promise<Array<IEncryptionPublicKey>> {
+  public static keys(url: string, electionId: string): Promise<IElectionKeysResponse> {
     return axios
       .get<IElectionKeysResponse>(url + ElectionAPIMethods.KEYS.replace('{id}', electionId))
-      .then((response) => response.data.publicKeys)
+      .then((response) => response.data)
       .catch(this.isApiError);
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -878,9 +878,11 @@ export class VocdoniSDKClient {
 
     let voteTx;
     if (election?.electionType.secretUntilTheEnd) {
-      voteTx = ElectionAPI.keys(this.url, election.id).then((encryptionPubKeys) =>
+      voteTx = ElectionAPI.keys(this.url, election.id).then((encryptionKeys) =>
         Promise.all([
-          VoteCore.generateVoteTransaction(election, censusProof, vote, { encryptionPubKeys }),
+          VoteCore.generateVoteTransaction(election, censusProof, vote, {
+            encryptionPubKeys: encryptionKeys.publicKeys,
+          }),
           this.fetchChainId(),
         ])
       );


### PR DESCRIPTION
- [x] Fix interface for `/elections/{id}/keys` showing the private keys also
- [x] Implement block to date (pending https://github.com/vocdoni/interoperability/issues/68)
- [x] Implement block transactions https://github.com/vocdoni/interoperability/issues/57
- [x] Implement date to block

FTR some of the tests used

```ts
it('Get transactions for a block', async () => {
    const url = 'https://api-dev.vocdoni.net/v2';
    const block = 99405;
    const transactions = await ChainAPI.blockTransactions(url, block, 0);
    expect(transactions.blockNumber).toBe(block);
  });

  it('convert block to date', async () => {
    const url = 'https://api-dev.vocdoni.net/v2';
    const block = 99405;
    const date = await ChainAPI.blockToDate(url, block);
    console.log(new Date(date.date));
  });

  it('convert date to block', async () => {
    const url = 'https://api-dev.vocdoni.net/v2';
    const date = Math.floor(new Date().getTime() / 1000);
    console.log(date);
    const block = await ChainAPI.dateToBlock(url, date);
    console.log(block);
  });
```