### PR TITLE
fix error code for ErrElectionNotFound and ErrNoElectionKeys

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -29,9 +29,9 @@ export abstract class API {
           throw new ErrCantParseElectionID(err['error']);
         case 4020:
           throw new ErrCantParsePayloadAsJSON(err['error']);
-        case 4046:
+        case 4045:
           throw new ErrElectionNotFound(err['error']);
-        case 4048:
+        case 4047:
           throw new ErrNoElectionKeys(err['error']);
         case 5003:
           return API.isVochainError(err['error']);


### PR DESCRIPTION
those two error codes were incorrectly shifted in
https://github.com/vocdoni/vocdoni-node/commit/42823fb20d61096ddd32ca4e0c27db54bd2862a4
and fixed back in
https://github.com/vocdoni/vocdoni-node/pull/1002
