### PR TITLE
Fix Election info interface

### DIFF
--- a/src/api/election.ts
+++ b/src/api/election.ts
@@ -13,57 +13,112 @@ enum ElectionAPIMethods {
   LIST_FILTERED = '/elections/filter/page/{page}',
 }
 
-export interface IResults {
-  value: string[];
-}
-
 export interface ICensus {
-  censusOrigin: string;
+  /**
+   * The type of the census
+   */
+  censusOrigin: CensusTypeEnum;
+
+  /**
+   * The root of the census
+   */
   censusRoot: string;
+
+  /**
+   * The post register root of the census
+   */
   postRegisterCensusRoot: string;
+
+  /**
+   * The URL of the census
+   */
   censusURL: string;
+
+  /**
+   * Max size of the census. How many voters the census can have.
+   */
+  maxCensusSize: number;
 }
 
 export interface IVoteMode {
+  /**
+   * If the vote is serial
+   */
   serial: boolean;
+
+  /**
+   * If the vote is anonymous
+   */
   anonymous: boolean;
+
+  /**
+   * If the vote is encrypted
+   */
   encryptedVotes: boolean;
+
+  /**
+   * If the vote values are unique
+   */
   uniqueValues: boolean;
+
+  /**
+   * Cost from weight of the election
+   */
   costFromWeight: boolean;
 }
 
 export interface IElectionMode {
+  /**
+   * If the election should start automatically
+   */
   autoStart: boolean;
+
+  /**
+   * If the election is interruptible
+   */
   interruptible: boolean;
+
+  /**
+   * If the election has a dynamic census
+   */
   dynamicCensus: boolean;
+
+  /**
+   * If the election has encrypted metadata
+   */
   encryptedMetaData: boolean;
+
+  /**
+   * If the election has preregister phase
+   */
   preRegister: boolean;
 }
 
 export interface ITallyMode {
+  /**
+   * The max count of the vote's values sum
+   */
   maxCount: number;
-  maxValue: number;
-  maxVoteOverwrites: number;
-  maxTotalCost: number;
-  costExponent: number;
-}
 
-export interface IElection {
-  electionId: string;
-  type: string;
-  status: string;
-  startDate: string;
-  endDate: string;
-  voteCount: number;
-  finalResults: boolean;
-  result: IResults[];
-  electionCount: number;
-  census: ICensus;
-  metadataURL: string;
-  creationTime: string;
-  voteMode: IVoteMode;
-  electionMode: IElectionMode;
-  tallyMode: ITallyMode;
+  /**
+   * The max value of the vote's values
+   */
+  maxValue: number;
+
+  /**
+   * The max number of votes overwrites
+   */
+  maxVoteOverwrites: number;
+
+  /**
+   * The max total cost of the votes
+   */
+  maxTotalCost: number;
+
+  /**
+   * The cost exponent of the vote
+   */
+  costExponent: number;
 }
 
 interface IElectionCreateResponse {
@@ -137,34 +192,9 @@ export interface IElectionInfoResponse {
   result?: Array<Array<string>>;
 
   /**
-   * The number of elections done by the account
-   */
-  electionCount: number;
-
-  /**
    * The census of the election
    */
-  census: {
-    /**
-     * The type of the census
-     */
-    censusOrigin: CensusTypeEnum;
-
-    /**
-     * The root of the census
-     */
-    censusRoot: string;
-
-    /**
-     * The post register root of the census
-     */
-    postRegisterCensusRoot: string;
-
-    /**
-     * The URL of the census
-     */
-    censusURL: string;
-  };
+  census: ICensus;
 
   /**
    * The URL of the metadata
@@ -179,92 +209,17 @@ export interface IElectionInfoResponse {
   /**
    * The voting mode of the election
    */
-  voteMode: {
-    /**
-     * If the vote is serial
-     */
-    serial: boolean;
-
-    /**
-     * If the vote is anonymous
-     */
-    anonymous: boolean;
-
-    /**
-     * If the vote is encrypted
-     */
-    encryptedVotes: boolean;
-
-    /**
-     * If the vote values are unique
-     */
-    uniqueValues: boolean;
-
-    /**
-     * Cost from weight of the election
-     */
-    costFromWeight: boolean;
-  };
+  voteMode: IVoteMode;
 
   /**
    * The election mode of the election
    */
-  electionMode: {
-    /**
-     * If the election should start automatically
-     */
-    autoStart: boolean;
-
-    /**
-     * If the election is interruptible
-     */
-    interruptible: boolean;
-
-    /**
-     * If the election has a dynamic census
-     */
-    dynamicCensus: boolean;
-
-    /**
-     * If the election has encrypted metadata
-     */
-    encryptedMetaData: boolean;
-
-    /**
-     * If the election has preregister phase
-     */
-    preRegister: boolean;
-  };
+  electionMode: IElectionMode;
 
   /**
    * The tally mode of the vote
    */
-  tallyMode: {
-    /**
-     * The max count of the vote's values sum
-     */
-    maxCount: number;
-
-    /**
-     * The max value of the vote's values
-     */
-    maxValue: number;
-
-    /**
-     * The max number of votes overwrites
-     */
-    maxVoteOverwrites: number;
-
-    /**
-     * The max total cost of the votes
-     */
-    maxTotalCost: number;
-
-    /**
-     * The cost exponent of the vote
-     */
-    costExponent: number;
-  };
+  tallyMode: ITallyMode;
 
   /**
    * The metadata of the election

--- a/src/client.ts
+++ b/src/client.ts
@@ -431,7 +431,6 @@ export class VocdoniSDKClient {
           voteCount: electionInfo.voteCount,
           finalResults: electionInfo.finalResults,
           results: electionInfo.result,
-          electionCount: electionInfo.electionCount,
           metadataURL: electionInfo.metadataURL,
           creationTime: electionInfo.creationTime,
           electionType: {

--- a/src/types/election/published.ts
+++ b/src/types/election/published.ts
@@ -26,7 +26,6 @@ export interface IPublishedElectionParameters extends IElectionParameters {
   voteCount: number;
   finalResults: boolean;
   results: Array<Array<string>>;
-  electionCount: number;
   creationTime: string;
   metadataURL: string;
   raw: object;
@@ -42,7 +41,6 @@ export class PublishedElection extends Election {
   private readonly _voteCount: number;
   private readonly _finalResults: boolean;
   private readonly _results: Array<Array<string>>;
-  private readonly _electionCount: number;
   private readonly _creationTime: Date;
   private readonly _metadataURL: string;
   private readonly _raw: object;
@@ -73,7 +71,6 @@ export class PublishedElection extends Election {
     this._voteCount = params.voteCount;
     this._finalResults = params.finalResults;
     this._results = params.results;
-    this._electionCount = params.electionCount;
     this._creationTime = new Date(params.creationTime);
     this._metadataURL = params.metadataURL;
     this._raw = params.raw;
@@ -163,10 +160,6 @@ export class PublishedElection extends Election {
 
   get results(): Array<Array<string>> {
     return this._results;
-  }
-
-  get electionCount(): number {
-    return this._electionCount;
   }
 
   get creationTime(): Date {


### PR DESCRIPTION
- Delete unused `IElection` interface in favor of `IElectionInfoResponse`
- Moved `IElectionInfoResponse` data to exported interfaces of `IResults` `ICensus` `IVoteMode` `IElectionMode` `ITallyMode`
- Added `cenus.maxCensusSize`
- Deleted `electionCount`