### PR TITLE
Add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
     "iso-language-codes": "^1.1.0",
     "tiny-invariant": "^1.3.1",
     "tweetnacl": "^1.0.3",
-    "yup": "^0.32.11"
+    "yup": "^0.32.11",
+    "wasmcurves": "0.2.1",
+    "web-worker": "^1.2.0"
   }
 }


### PR DESCRIPTION
We're adding to our dependencies the dependencies from ffjavascript, because since we're bundling ffjavascript package, and it's a second level dependency, its package.json gets removed, and its dependencies are not fetched by end-developers.

Adding these dependencies to our package.json file ensures these developers will properly download the missing dependencies.

To reproduce the issue of missing dependencies, simply clone this project, and try to run an example **without installing sdk dependencies first**, just install the examples' dependencies using `yarn` in the example folder, and then run `yarn start`.