### PR TITLE
 Adds missing bundle dependencies blake2b and wasmbuilder

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,11 +121,13 @@
     "@size-limit/file": "^8.2.4",
     "@vocdoni/proto": "1.14.1",
     "axios": "0.27.2",
+    "blake2b": "^2.1.4",
     "iso-language-codes": "^1.1.0",
     "tiny-invariant": "^1.3.1",
     "tweetnacl": "^1.0.3",
-    "yup": "^0.32.11",
+    "wasmbuilder": "^0.0.16",
     "wasmcurves": "0.2.1",
-    "web-worker": "^1.2.0"
+    "web-worker": "^1.2.0",
+    "yup": "^0.32.11"
   }
 }


### PR DESCRIPTION
As with https://github.com/vocdoni/vocdoni-sdk/pull/227 :

Adding these dependencies to our package.json file ensures these developers will properly download the missing dependencies.

To reproduce the issue of missing dependencies, simply clone this project, and try to run an example without installing sdk dependencies first, just install the examples' dependencies using yarn in the example folder, and then run yarn start.