### PR TITLE
Remove unnecessary SDK install on examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,9 +16,6 @@ jobs:
         with:
           node-version: 18.x
 
-      - name: Install deps and build SDK
-        run: yarn
-
       - name: Install deps and build CRA example
         run: |
           cd examples/cra


### PR DESCRIPTION
Since we set a fixed version for the SDK, there's no need to install and fetch SDK dependencies when installing the examples' ones.

Removing this line could also show issues like #227, that did not fail before because it does not fail if yarn can find dependencies on a parent folder.