### PR TITLE
Fix docs generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,13 +10,13 @@ This library export the JSDocs to `.mdx` format, which is compatible with docusa
 Run:
 
 ```bash
-npm install
+yarn
 ```
 
 Then you can just run the npm script:
 
 ```bash
-npm run build
+yarn build
 ```
 
 This will generate a `temp_docs` folder with all generated documentation. It also copies de `../README.md` into 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -56,7 +56,7 @@ export function formatUnits(value: BigNumberish, decimals: number = 18): string 
  *
  * @param {any} obj Object to be accessed by dot notation
  * @param {string} dot Dot notation string to extract object data
- * @returns
+ * @returns {any} Return the object data
  */
 export const dotobject = (obj: any, dot: string) => {
   const rec = (obj: any, dot: string[]): any => {


### PR DESCRIPTION
Fix the error message

> Cannot use 'in' operator to search for 'description' in null

Also change `npm` for `yarn` on README.md