### PR TITLE
Add missing dependency readable-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "axios": "0.27.2",
     "blake2b": "^2.1.4",
     "iso-language-codes": "^1.1.0",
+    "readable-stream": "^4.4.2",
     "tiny-invariant": "^1.3.1",
     "tweetnacl": "^1.0.3",
     "wasmbuilder": "^0.0.16",


### PR DESCRIPTION
It's a dependency from blake-hash, and since blake-hash is treated as internal, its dependencies should be added to our package.json file

I tried adding readable-stream as an internal dependency, but doing that caused side-effects due to the version being compiled.