### PR TITLE
Added anonymous support for Census3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Census3 error typings.
+- Census3 anonymous censuses.
 
 ## [0.1.1] - 2023-08-14
 

--- a/src/census3.ts
+++ b/src/census3.ts
@@ -177,8 +177,6 @@ export class VocdoniCensus3Client {
 
     const waitForQueue = (queueId: string): Promise<Census3Census> => {
       return Census3CensusAPI.queue(this.url, queueId).then((queue) => {
-        console.log(queueId);
-        console.log(queue);
         switch (true) {
           case queue.done && queue.error?.code?.toString().length > 0:
             return Promise.reject(new Error('Could not create the census'));

--- a/src/types/census/census3.ts
+++ b/src/types/census/census3.ts
@@ -13,12 +13,20 @@ export class TokenCensus extends PublishedCensus {
    *
    * @param censusId The id of the census
    * @param censusURI The URI of the census
+   * @param anonymous If the census is anonymous
    * @param token The token of the census
    * @param size The size of the census
    * @param weight The weight of the census
    */
-  public constructor(censusId: string, censusURI: string, token: Token, size?: number, weight?: bigint) {
-    super(censusId, censusURI, CensusType.WEIGHTED, size, weight);
+  public constructor(
+    censusId: string,
+    censusURI: string,
+    anonymous: boolean,
+    token: Token,
+    size?: number,
+    weight?: bigint
+  ) {
+    super(censusId, censusURI, anonymous ? CensusType.ANONYMOUS : CensusType.WEIGHTED, size, weight);
     this.token = token;
   }
 


### PR DESCRIPTION
You can test it by passing the anonymous flag to the `createTokenCensus`:

```ts
const census = await client.createTokenCensus('0xa117000000f279d81a1d3cc75430faa017fa5a2e', true);
```