### PR TITLE
New `createElectionSteps` function in client for using async generators and control creation flow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `createElectionSteps` function in client for using async generators and control creation flow.
+
 ## [0.3.0] - 2023-09-13
 
 ### Fixed

--- a/src/services/election.ts
+++ b/src/services/election.ts
@@ -24,6 +24,27 @@ export interface FetchElectionsParameters {
 export type ElectionKeys = IElectionKeysResponse;
 export type ElectionCreatedInformation = IElectionCreateResponse;
 
+export enum ElectionCreationSteps {
+  GET_CHAIN_DATA = 'get-chain-data',
+  CENSUS_CREATED = 'census-created',
+  GET_ACCOUNT_DATA = 'get-account-data',
+  GET_ELECTION_DATA_PIN = 'get-election-data-pin',
+  GENERATE_TX = 'generate-new-election-tx',
+  SIGN_TX = 'sign-new-election-tx',
+  CREATING = 'creating',
+  DONE = 'done',
+}
+
+export type ElectionCreationStepValue =
+  | { key: ElectionCreationSteps.GET_CHAIN_DATA }
+  | { key: ElectionCreationSteps.CENSUS_CREATED }
+  | { key: ElectionCreationSteps.GET_ACCOUNT_DATA }
+  | { key: ElectionCreationSteps.GET_ELECTION_DATA_PIN }
+  | { key: ElectionCreationSteps.GENERATE_TX }
+  | { key: ElectionCreationSteps.SIGN_TX }
+  | { key: ElectionCreationSteps.CREATING; txHash: string }
+  | { key: ElectionCreationSteps.DONE; electionId: string };
+
 export class ElectionService extends Service implements ElectionServiceProperties {
   public censusService: CensusService;
   public chainService: ChainService;

--- a/test/integration/election.test.ts
+++ b/test/integration/election.test.ts
@@ -2,6 +2,7 @@ import { Wallet } from '@ethersproject/wallet';
 import {
   CensusType,
   Election,
+  ElectionCreationSteps,
   ElectionStatus,
   PlainCensus,
   PublishedCensus,
@@ -116,6 +117,18 @@ describe('Election integration tests', () => {
         expect(publishedElection.maxCensusSize).toEqual(1);
       });
   }, 85000);
+  it('should create an election step by step', async () => {
+    const census = new PlainCensus();
+    census.add(await Wallet.createRandom().getAddress());
+
+    const election = createElection(census);
+
+    await client.createAccount();
+
+    for await (const value of client.createElectionSteps(election)) {
+      expect(Object.values(ElectionCreationSteps)).toContain(value.key);
+    }
+  }, 850000);
   it('should create an election with addresses census', async () => {
     const census = new PlainCensus();
 


### PR DESCRIPTION
To discuss if it's necessary to return more data in the different steps (cid, encoded tx)?