### PR TITLE
New `sendTokens` function in client for transferring tokens between accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `createElectionSteps` function in client for using async generators and control creation flow.
+- New `sendTokens` function in client for transferring tokens between accounts.
 
 ## [0.3.0] - 2023-09-13
 

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -5,6 +5,7 @@ import {
   ProofArbo_KeyType,
   ProofArbo_Type,
   RegisterSIKTx,
+  SendTokensTx,
   SetAccountTx,
   Tx,
   TxType,
@@ -99,6 +100,20 @@ export abstract class AccountCore extends TransactionCore {
 
     return Tx.encode({
       payload: { $case: 'registerSIK', registerSIK },
+    }).finish();
+  }
+
+  public static generateTransferTransaction(nonce: number, from: string, to: string, amount): Uint8Array {
+    const sendTokens = SendTokensTx.fromPartial({
+      txtype: TxType.SEND_TOKENS,
+      nonce: nonce,
+      from: new Uint8Array(Buffer.from(strip0x(from), 'hex')),
+      to: new Uint8Array(Buffer.from(strip0x(to), 'hex')),
+      value: amount,
+    });
+
+    return Tx.encode({
+      payload: { $case: 'sendTokens', sendTokens },
     }).finish();
   }
 

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -119,7 +119,7 @@ export class ChainService extends Service implements ChainServiceProperties {
     const waitTime = wait ?? this.txWait?.retryTime;
     const attemptsNum = attempts ?? this.txWait?.attempts;
     invariant(waitTime, 'No transaction wait time set');
-    invariant(attemptsNum, 'No transaction attempts set');
+    invariant(attemptsNum >= 0, 'No transaction attempts set');
 
     return attemptsNum === 0
       ? Promise.reject('Time out waiting for transaction: ' + tx)

--- a/src/types/client/account.ts
+++ b/src/types/client/account.ts
@@ -1,0 +1,5 @@
+import { Wallet } from '@ethersproject/wallet';
+import { Signer } from '@ethersproject/abstract-signer';
+
+export type WalletOption = { wallet: Wallet | Signer };
+export type SendTokensOptions = Partial<WalletOption> & { to: string; amount: number };

--- a/src/types/client/index.ts
+++ b/src/types/client/index.ts
@@ -1,0 +1,1 @@
+export * from './account';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './client';
 export * from './vote/index';
 export * from './metadata/index';
 export * from './election/index';


### PR DESCRIPTION
Usage:

```ts
    await client
      .sendTokens({ to: destinationAccount.address, amount: TOKENS_AMOUNT })
      .then(() => client.fetchAccountInfo())
      .then((accountData) => expect(accountData.balance).toEqual(accountInfo.balance - TOKENS_AMOUNT - SEND_TX_COST))
      .then(() => destinationClient.fetchAccountInfo())
      .then((destinationData) => expect(destinationData.balance).toEqual(destinationInfo.balance + TOKENS_AMOUNT));
```