### PR TITLE
Fix bundle tests

### DIFF
--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -41,7 +41,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "\"@vocdoni/sdk\":[^\n]+"
-          replace: "\"@vocdoni/sdk\": \"file:../../../sdk-bundle-tests.tgz\""
+          replace: "\"@vocdoni/sdk\": \"../../../sdk-bundle-tests.tgz\""
           regex: true
           include: "test/bundle/${{ matrix.example }}/package.json"
 


### PR DESCRIPTION
Apparently yarn does weird things when using `file:`... by "weird things" I mean adding strange files to our bundle, and using those extraneous files instead of the expected ones.