### PR TITLE
Added token summary in Census3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Supported tokens from Census3 using `getSupportedTokens()` returns now a token summary.
+
 ### Added
 
 - Added `ArchivedAccountData` for dealing with archived accounts and new `fetchAccount` function in client.

--- a/src/api/census3/token.ts
+++ b/src/api/census3/token.ts
@@ -9,6 +9,8 @@ enum Census3TokenAPIMethods {
   HOLDER = '/tokens/{tokenID}/holders/{holderID}?chainID={chainID}',
 }
 
+export type Census3SummaryToken = Omit<Census3Token, 'status' | 'size'> & { synced: boolean };
+
 export type Census3Token = {
   /**
    * The id (address) of the token.
@@ -19,6 +21,11 @@ export type Census3Token = {
    * The name of the token.
    */
   name: string;
+
+  /**
+   * The size (token holders) of the token.
+   */
+  size: number;
 
   /**
    * The type of the token.
@@ -100,7 +107,7 @@ export interface ICensus3TokenListResponse {
   /**
    * The list of the tokens
    */
-  tokens: Array<Census3Token>;
+  tokens: Array<Census3SummaryToken>;
 }
 
 export interface ICensus3TokenListResponsePaginated extends ICensus3TokenListResponse {

--- a/src/census3.ts
+++ b/src/census3.ts
@@ -12,6 +12,7 @@ import {
   Census3CreateStrategyToken,
   ICensus3ValidatePredicateResponse,
   ICensus3StrategiesOperator,
+  Census3SummaryToken,
 } from './api';
 import invariant from 'tiny-invariant';
 import { isAddress } from '@ethersproject/address';
@@ -19,6 +20,7 @@ import { TokenCensus } from './types';
 import { delay } from './util/common';
 
 export type Token = Omit<Census3Token, 'tags'> & { tags: string[] };
+export type TokenSummary = Omit<Census3SummaryToken, 'tags'> & { tags: string[] };
 export type Strategy = Census3Strategy;
 export type StrategyToken = Census3CreateStrategyToken;
 export type Census3Census = ICensus3CensusResponse;
@@ -48,11 +50,11 @@ export class VocdoniCensus3Client {
   }
 
   /**
-   * Returns a list of tokens supported by the service
+   * Returns a list of summary tokens supported by the service
    *
-   * @returns {Promise<Token[]>} Token list
+   * @returns {Promise<TokenSummary[]>} Token summary list
    */
-  getSupportedTokens(): Promise<Token[]> {
+  getSupportedTokens(): Promise<TokenSummary[]> {
     return Census3TokenAPI.list(this.url, { pageSize: -1 }).then(
       (list) =>
         list?.tokens?.map((token) => ({


### PR DESCRIPTION
Supported tokens from Census3 using `getSupportedTokens()` returns now a token summary