### PR TITLE
Client: add cspInfo call to cspUrl

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -988,7 +988,12 @@ export class VocdoniSDKClient {
   }
 
   async cspInfo() {
-    return this.cspService.setInfo();
+    if (this.cspService.url) {
+      return this.cspService.setInfo();
+    }
+    // If the CSP url is not set, attempt to set it from the election ID
+    invariant(this.electionId, 'No election id or CSP URL set');
+    return this.cspUrl().then(() => this.cspService.setInfo());
   }
 
   async cspStep(stepNumber: number, data: any[], authToken?: string) {


### PR DESCRIPTION
Adds a call to `cspUrl()` in `client.cspInfo()`. 

This fixes a behavior where `client.cspInfo()` would return a `No CSP URL set` error when called before the client has registered any voters. This is because the CSP URL is currently only set during `cspStep` for voter validation. 

Target behavior: `client.cspInfo()` should be usable once the client has created an election using a CSP census, even if no voters have registered.