### PR TITLE
Fix docs generation

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,7 @@
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["../src"],
   "compilerOptions": {
-    "lib": ["esnext"],
+    "lib": ["esnext", "DOM"],
     "allowJs": true,
     "target": "esnext",
     "resolveJsonModule": true,


### PR DESCRIPTION
It fixes an error during the docs build:

```
../node_modules/axios/index.d.ts:153:38 - error TS2304: Cannot find name 'ProgressEvent'.
```

Following [this thread](https://github.com/axios/axios/issues/3219) thread, seems that simply adding `DOM` to libs on tsconfig fix the issue:

https://github.com/axios/axios/issues/3219#issuecomment-711116893