### PR TITLE
Implements txByIndex

### DIFF
--- a/src/api/chain.ts
+++ b/src/api/chain.ts
@@ -9,6 +9,7 @@ enum ChainAPIMethods {
   COSTS = '/chain/info/electionPriceFactors',
   CIRCUITS = '/chain/info/circuit',
   TX_INFO = '/chain/transactions/reference',
+  TX_INFO_BY_INDEX = '/chain/transactions/reference/index/{index}',
   TX_INFO_BLOCK = '/chain/transactions/{blockHeight}/{txIndex}',
   SUBMIT_TX = '/chain/transactions',
   TX_LIST = '/chain/transactions/page',
@@ -458,6 +459,18 @@ export abstract class ChainAPI extends API {
   public static txInfo(url: string, txHash: string): Promise<IChainTxReference> {
     return axios
       .get<IChainTxReference>(url + ChainAPIMethods.TX_INFO + '/' + txHash)
+      .then((response) => {
+        if (response.status === 204) {
+          throw new ErrTransactionNotFound();
+        }
+        return response.data;
+      })
+      .catch(this.isApiError);
+  }
+
+  public static txByIndex(url: string, index: number): Promise<IChainTxReference> {
+    return axios
+      .get<IChainTxReference>(url + ChainAPIMethods.TX_INFO_BY_INDEX.replace('{index}', String(index)))
       .then((response) => {
         if (response.status === 204) {
           throw new ErrTransactionNotFound();

--- a/test/api/chain.test.ts
+++ b/test/api/chain.test.ts
@@ -13,4 +13,9 @@ describe('Chain API tests', () => {
       await ChainAPI.txInfo(URL, '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
     }).rejects.toThrow(ErrTransactionNotFound);
   }, 5000);
+  it('should throw when asking for a non existent transaction by index', async () => {
+    await expect(async () => {
+      await ChainAPI.txByIndex(URL, 0);
+    }).rejects.toThrow(ErrTransactionNotFound);
+  }, 5000);
 });


### PR DESCRIPTION
This will be used on the explorer. This endpoint return the `IChainTxReference` by the tx index. Related api endpoint: https://developer.vocdoni.io/vocdoni-api/transaction-by-index 