### PR TITLE
Fix tx and proof types

### DIFF
--- a/src/api/chain/transactions.ts
+++ b/src/api/chain/transactions.ts
@@ -341,91 +341,97 @@ export declare enum TxType {
   UNRECOGNIZED = -1,
 }
 
-export interface Proof {
-  payload?:
-    | {
-        $case: 'graviton';
-        graviton: {
-          siblings: Uint8Array;
-        };
-      }
-    | {
-        $case: 'iden3';
-        iden3: {
-          siblings: Uint8Array;
-        };
-      }
-    | {
-        $case: 'ethereumStorage';
-        ethereumStorage: {
+export type GravitonType = {
+  graviton: {
+    siblings: Uint8Array;
+  };
+};
+
+export type Id3Type = {
+  iden3: {
+    siblings: Uint8Array;
+  };
+};
+
+export type EthereumStorageType = {
+  ethereumStorage: {
+    key: Uint8Array;
+    value: Uint8Array;
+    siblings: Uint8Array[];
+  };
+};
+
+export type EthereumAccountType = {
+  ethereumAccount: {
+    nonce: Uint8Array;
+    /** Big Int encoded as bytes */
+    balance: Uint8Array;
+    storageHash: Uint8Array;
+    codeHash: Uint8Array;
+    siblings: Uint8Array[];
+  };
+};
+
+export type CAType = {
+  ca: {
+    type: ProofCA_Type;
+    bundle:
+      | {
+          processId: Uint8Array;
+          address: Uint8Array;
+        }
+      | undefined;
+    signature: Uint8Array;
+  };
+};
+
+export type ArboType = {
+  arbo: {
+    type: ProofArbo_Type;
+    siblings: Uint8Array;
+    value: Uint8Array;
+    keyType: ProofArbo_KeyType;
+  };
+};
+
+export type ZkSnarkType = {
+  zkSnark: {
+    circuitParametersIndex: number;
+    a: string[];
+    b: string[];
+    c: string[];
+    publicInputs: string[];
+  };
+};
+
+export type MinimeStorageType = {
+  minimeStorage: {
+    proofPrevBlock:
+      | {
           key: Uint8Array;
           value: Uint8Array;
           siblings: Uint8Array[];
-        };
-      }
-    | {
-        $case: 'ethereumAccount';
-        ethereumAccount: {
-          nonce: Uint8Array;
-          /** Big Int encoded as bytes */
-          balance: Uint8Array;
-          storageHash: Uint8Array;
-          codeHash: Uint8Array;
-          siblings: Uint8Array[];
-        };
-      }
-    | {
-        $case: 'ca';
-        ca: {
-          type: ProofCA_Type;
-          bundle:
-            | {
-                processId: Uint8Array;
-                address: Uint8Array;
-              }
-            | undefined;
-          signature: Uint8Array;
-        };
-      }
-    | {
-        $case: 'arbo';
-        arbo: {
-          type: ProofArbo_Type;
-          siblings: Uint8Array;
+        }
+      | undefined;
+    proofNextBlock?:
+      | {
+          key: Uint8Array;
           value: Uint8Array;
-          keyType: ProofArbo_KeyType;
-        };
-      }
-    | {
-        $case: 'zkSnark';
-        zkSnark: {
-          circuitParametersIndex: number;
-          a: string[];
-          b: string[];
-          c: string[];
-          publicInputs: string[];
-        };
-      }
-    | {
-        $case: 'minimeStorage';
-        minimeStorage: {
-          proofPrevBlock:
-            | {
-                key: Uint8Array;
-                value: Uint8Array;
-                siblings: Uint8Array[];
-              }
-            | undefined;
-          proofNextBlock?:
-            | {
-                key: Uint8Array;
-                value: Uint8Array;
-                siblings: Uint8Array[];
-              }
-            | undefined;
-        };
-      };
-}
+          siblings: Uint8Array[];
+        }
+      | undefined;
+  };
+};
+
+export type Proof =
+  | GravitonType
+  | Id3Type
+  | EthereumStorageType
+  | EthereumAccountType
+  | CAType
+  | ArboType
+  | ZkSnarkType
+  | MinimeStorageType;
 
 declare enum ProofCA_Type {
   UNKNOWN = 0,

--- a/src/api/chain/transactions.ts
+++ b/src/api/chain/transactions.ts
@@ -1,55 +1,59 @@
 import { IChainTxReference } from '../chain';
 
+export type VoteEnvelopeType = {
+  vote: VoteEnvelope;
+};
+
+export type NewProcessTxType = {
+  newProcess: NewProcessTx;
+};
+
+export type AdminTxType = {
+  admin: AdminTx;
+};
+
+export type SetProcessTxType = {
+  setProcess: SetProcessTx;
+};
+
+export type RegisterKeyTxType = {
+  registerKey: RegisterKeyTx;
+};
+
+export type MintTokensTxType = {
+  mintTokens: MintTokensTx;
+};
+
+export type SendTokensTxType = {
+  sendTokens: SendTokensTx;
+};
+
+export type SetTransactionCostsTxType = {
+  setTransactionCosts: SetTransactionCostsTx;
+};
+
+export type SetAccountTxType = {
+  setAccount: SetAccountTx;
+};
+
+export type CollectFaucetTxType = {
+  collectFaucet: CollectFaucetTx;
+};
+
+export type TxTypes =
+  | VoteEnvelopeType
+  | NewProcessTxType
+  | AdminTxType
+  | SetProcessTxType
+  | RegisterKeyTxType
+  | MintTokensTxType
+  | SendTokensTxType
+  | SetTransactionCostsTxType
+  | SetAccountTxType
+  | CollectFaucetTxType;
+
 export interface Tx {
-  tx?:
-    | {
-        $case: 'vote';
-        vote: VoteEnvelope;
-      }
-    | {
-        $case: 'newProcess';
-        newProcess: NewProcessTx;
-      }
-    | {
-        $case: 'admin';
-        admin: AdminTx;
-      }
-    | {
-        $case: 'setProcess';
-        setProcess: SetProcessTx;
-      }
-    | {
-        $case: 'registerKey';
-        registerKey: RegisterKeyTx;
-      }
-    | {
-        $case: 'mintTokens';
-        mintTokens: MintTokensTx;
-      }
-    | {
-        $case: 'sendTokens';
-        sendTokens: SendTokensTx;
-      }
-    | {
-        $case: 'setTransactionCosts';
-        setTransactionCosts: SetTransactionCostsTx;
-      }
-    | {
-        $case: 'setAccount';
-        setAccountInfo: SetAccountTx;
-      }
-    // | {
-    //     $case: 'setAccountDelegateTx';
-    //     setAccountDelegateTx: SetAccountDelegateTx;
-    //   }
-    | {
-        $case: 'collectFaucet';
-        collectFaucet: CollectFaucetTx;
-      };
-  // | {
-  //     $case: 'setKeykeeper';
-  //     collectFaucet: SetKeyKeeperTx;
-  //   };
+  tx?: TxTypes;
   txInfo: IChainTxReference;
 }
 

--- a/src/api/chain/typeguards.ts
+++ b/src/api/chain/typeguards.ts
@@ -1,0 +1,54 @@
+import {
+  AdminTxType,
+  CollectFaucetTxType,
+  MintTokensTxType,
+  NewProcessTxType,
+  RegisterKeyTxType,
+  SendTokensTxType,
+  SetAccountTxType,
+  SetProcessTxType,
+  SetTransactionCostsTxType,
+  TxTypes,
+  VoteEnvelopeType,
+} from './transactions';
+import { TransactionType } from '../chain';
+
+export const isVoteEnvelopeType = (tx: TxTypes): tx is VoteEnvelopeType => {
+  return TransactionType.VOTE_ENVELOPE in tx;
+};
+
+export const isNewProcessTxType = (tx: TxTypes): tx is NewProcessTxType => {
+  return TransactionType.NEW_PROCESS_TX in tx;
+};
+
+export const isAdminTx = (tx: TxTypes): tx is AdminTxType => {
+  return TransactionType.ADMIN_TX in tx;
+};
+
+export const isSetProcessTx = (tx: TxTypes): tx is SetProcessTxType => {
+  return TransactionType.SET_PROCESS_TX in tx;
+};
+
+export const isRegisterKeyTx = (tx: TxTypes): tx is RegisterKeyTxType => {
+  return TransactionType.REGISTER_KEY_TX in tx;
+};
+
+export const isMintTokensTx = (tx: TxTypes): tx is MintTokensTxType => {
+  return TransactionType.MINT_TOKENS_TX in tx;
+};
+
+export const isSendTokensTx = (tx: TxTypes): tx is SendTokensTxType => {
+  return TransactionType.SEND_TOKENS_TX in tx;
+};
+
+export const isSetTransactionCostTx = (tx: TxTypes): tx is SetTransactionCostsTxType => {
+  return TransactionType.SET_TRANSACTION_COSTS_TX in tx;
+};
+
+export const isSetAccountTx = (tx: TxTypes): tx is SetAccountTxType => {
+  return TransactionType.SET_ACCOUNT_TX in tx;
+};
+
+export const isCollectFaucetTx = (tx: TxTypes): tx is CollectFaucetTxType => {
+  return TransactionType.COLLECT_FAUCET_TX in tx;
+};

--- a/src/api/chain/typeguards.ts
+++ b/src/api/chain/typeguards.ts
@@ -1,8 +1,16 @@
 import {
   AdminTxType,
+  ArboType,
+  CAType,
   CollectFaucetTxType,
+  EthereumAccountType,
+  EthereumStorageType,
+  GravitonType,
+  Id3Type,
+  MinimeStorageType,
   MintTokensTxType,
   NewProcessTxType,
+  Proof,
   RegisterKeyTxType,
   SendTokensTxType,
   SetAccountTxType,
@@ -10,6 +18,7 @@ import {
   SetTransactionCostsTxType,
   TxTypes,
   VoteEnvelopeType,
+  ZkSnarkType,
 } from './transactions';
 import { TransactionType } from '../chain';
 
@@ -51,4 +60,29 @@ export const isSetAccountTx = (tx: TxTypes): tx is SetAccountTxType => {
 
 export const isCollectFaucetTx = (tx: TxTypes): tx is CollectFaucetTxType => {
   return TransactionType.COLLECT_FAUCET_TX in tx;
+};
+
+export const isGravitonType = (proof: Proof): proof is GravitonType => {
+  return 'graviton' in proof;
+};
+export const isId3Type = (proof: Proof): proof is Id3Type => {
+  return 'iden3' in proof;
+};
+export const isEthereumStorageType = (proof: Proof): proof is EthereumStorageType => {
+  return 'ethereumStorage' in proof;
+};
+export const isEthereumAccountType = (proof: Proof): proof is EthereumAccountType => {
+  return 'ethereumAccount' in proof;
+};
+export const isCAType = (proof: Proof): proof is CAType => {
+  return 'ca' in proof;
+};
+export const isArboType = (proof: Proof): proof is ArboType => {
+  return 'arbo' in proof;
+};
+export const isZkSnarkType = (proof: Proof): proof is ZkSnarkType => {
+  return 'zkSnark' in proof;
+};
+export const isMinimeStorageType = (proof: Proof): proof is MinimeStorageType => {
+  return 'minimeStorage' in proof;
 };


### PR DESCRIPTION
The actual typing is not really working (it was an inheritance from generated TS code from protobuff and is simply wrong on this case). 

This refactor fixes Transactions and  Proof types and add typeguards for this types.

Some fast tests done:

```ts
it('should throw when asking for a non existent transaction by index', async () => {
    // await expect(async () => {
    const tx = await ChainAPI.txInfoByBlock(URL, 197870, 0);
    if (isVoteEnvelopeType(tx.tx)) {
      const voteEnvelope = tx.tx.vote;
      console.log('VoteEnvelopeType:', voteEnvelope.votePackage);
    }
    if (isNewProcessTxType(tx.tx)) {
      throw new Error('Should not enter here');
    }
    // }).rejects.toThrow(ErrTransactionNotFound);
  }, 5000);

  it('test type infering for proofs', async () => {
    // await expect(async () => {
    const tx = await ChainAPI.txInfoByBlock(URL, 39018, 121);
    // Es podrien fer servir funcions de typeguard
    if (isVoteEnvelopeType(tx.tx)) {
      const voteEnvelope = tx.tx.vote;
      if (isArboType(voteEnvelope.proof)) {
        console.log('proof:', voteEnvelope.proof.arbo.siblings);
      }
      if (isMinimeStorageType(voteEnvelope.proof)) {
        throw new Error('Should not enter here');
      }
    }
    // }).rejects.toThrow(ErrTransactionNotFound);
  }, 5000);
```