### PR TITLE
Export missing account return types

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -18,7 +18,7 @@ enum AccountAPIMethods {
 
 export type IAccountSummary = Pick<IAccountInfoResponse, 'address' | 'balance' | 'nonce'>;
 
-interface IAccountInfoResponse {
+export interface IAccountInfoResponse {
   /**
    * The address of the account
    */
@@ -67,7 +67,7 @@ interface IAccountSetInfoResponse {
   metadataURL: number;
 }
 
-interface IAccountTransfer {
+export interface IAccountTransfer {
   amount: number;
   from: string;
   height: number;
@@ -76,7 +76,7 @@ interface IAccountTransfer {
   to: string;
 }
 
-interface IAccountTransfersResponse {
+export interface IAccountTransfersResponse {
   transfers: {
     received: Array<IAccountTransfer>;
     sent: Array<IAccountTransfer>;


### PR DESCRIPTION
This return types are needed for the extended SDK to implement some features of https://github.com/vocdoni/explorer/issues/65