### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/02_release_publish.yml
+++ b/.github/workflows/02_release_publish.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/scan_vuln_deps.yml
+++ b/.github/workflows/scan_vuln_deps.yml
@@ -28,7 +28,7 @@ jobs:
       ## The 'fs' scan mode requires *.lock files in order to scan vulns
       ## and to collect license info of packages, then you should run npm install before.
       - name: Setup NodeJS before scanning with Trivy
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 


### PR DESCRIPTION
Maintenance update: switch all jobs to setup-node@v4 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v4.0.0 release](https://github.com/actions/setup-node/releases/tag/v4.0.0).