### PR TITLE
CI: migrate workflows to upload-artifact v4

### DIFF
--- a/.github/workflows/scan_vuln_deps.yml
+++ b/.github/workflows/scan_vuln_deps.yml
@@ -63,7 +63,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Repo Scan Results as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: trivy-results-repo-${{ steps.myvars.outputs.DATE_IN_SECS }}


### PR DESCRIPTION
Maintenance update: migrating to upload-artifact@v4 for improved artifact handling. Pure maintenance, behavior unchanged. See the [v4.6.2 release](https://github.com/actions/upload-artifact/releases) for details.