### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/01_release_tagging.yml
+++ b/.github/workflows/01_release_tagging.yml
@@ -24,7 +24,7 @@ jobs:
       PKG_VER_FINAL: ${{ steps.getinfo.outputs.pkg_ver_final }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       ## Tag pattern: v1.2.3-xyz
       - name: Get PR labels and pkg version

--- a/.github/workflows/02_release_publish.yml
+++ b/.github/workflows/02_release_publish.yml
@@ -18,7 +18,7 @@ jobs:
       IS_DRYRUN: ${{ steps.taginfo.outputs.is_dryrun }}         ## yes|not
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       ## Tag pattern: v1.2.3-xyz
       ## Version pattern: 1.2.3
@@ -45,7 +45,7 @@ jobs:
     needs: [prepare]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -70,7 +70,7 @@ jobs:
     needs: [prepare]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       ## The CHANGELOG.md must contain the current version being published (i.e. [1.2.3])"
       - name: Check if CHANGELOG.md is updated

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout vocdoni-sdk repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install node
         uses: actions/setup-node@v3
@@ -36,7 +36,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Checkout developer-portal repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: vocdoni/developer-portal
           ref: main

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3
@@ -51,7 +51,7 @@ jobs:
       # TODO: somehow reuse artifact from ubuntu-latest 'build' job?
       # instead of building from scratch on self-hosted
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/.github/workflows/scan_vuln_deps.yml
+++ b/.github/workflows/scan_vuln_deps.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set myvars
         id: myvars

--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0