### PR TITLE
Upgrade @vocdoni/proto to 1.15.13 and add vote memo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,34 @@ option (or options) being voted:
 })();
 ~~~
 
+#### Vote memo
+
+Votes can optionally carry a free-text note of up to 256 bytes, useful for an
+open "Other" answer. It travels inside the vote envelope and is read back from
+the votes endpoint:
+
+~~~ts
+(async () => {
+  const vote = new Vote([0, 2], 'Other: none of the above');
+  const voteId = await client.submitVote(vote);
+
+  const info = await client.voteService.info(voteId);
+  console.log(info.memo); // "Other: none of the above"
+})();
+~~~
+
+The memo is also available on `AnonymousVote` and `CspVote`, either through their
+constructors or the inherited `memo` property.
+
+Two things to keep in mind:
+
+- The memo is gated behind a soft fork on the chain side. Until it activates for
+  the chain you are voting on, the memo is silently ignored: it is not stored,
+  not hashed into the vote and not returned by the API.
+- On anonymous elections the vote transaction is not signed and the memo is not
+  covered by the zk proof, so it can be altered in transit. Free text also
+  weakens the anonymity set. Do not put anything sensitive in it.
+
 ### Other SDK functionalities
 
 #### Generate a random Wallet

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@ethersproject/units": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@size-limit/file": "^8.2.4",
-    "@vocdoni/proto": "1.15.12",
+    "@vocdoni/proto": "1.15.13",
     "axios": "0.28.1",
     "blakejs": "^1.2.1",
     "blindsecp256k1": "^0.0.9",

--- a/src/api/chain/transactions.ts
+++ b/src/api/chain/transactions.ts
@@ -80,7 +80,8 @@ export interface VoteEnvelope {
    * */
   encryptionKeyIndexes: number[];
   /**
-   * Optional free-text note attached by the voter (max 256 bytes), encoded as bytes
+   * Optional free-text note attached by the voter (max 256 bytes), encoded as bytes.
+   * This is the raw envelope value; for the decoded note see `VoteInfoResponse.memo`
    * */
   memo?: string;
 }

--- a/src/api/chain/transactions.ts
+++ b/src/api/chain/transactions.ts
@@ -79,6 +79,10 @@ export interface VoteEnvelope {
    * On encrypted votes, contains the (sorted) indexes of the keys used to encrypt
    * */
   encryptionKeyIndexes: number[];
+  /**
+   * Optional free-text note attached by the voter (max 256 bytes), encoded as bytes
+   * */
+  memo?: string;
 }
 
 export interface NewProcessTx {

--- a/src/api/vote.ts
+++ b/src/api/vote.ts
@@ -51,7 +51,7 @@ export interface VotesList {
 
 export type VoteSummary = Pick<
   VoteInfoResponse,
-  'txHash' | 'voteID' | 'voterID' | 'electionID' | 'blockHeight' | 'transactionIndex'
+  'txHash' | 'voteID' | 'voterID' | 'electionID' | 'blockHeight' | 'transactionIndex' | 'memo'
 >;
 
 export type VoteInfoResponse = {
@@ -109,6 +109,14 @@ export type VoteInfoResponse = {
    * Date when the vote was emitted
    */
   date: string;
+
+  /**
+   * The optional free-text note attached by the voter, as plain text.
+   *
+   * Absent when the vote carries no memo, and also when the memo soft fork was
+   * not active on the chain at the time the vote was cast.
+   */
+  memo?: string;
 };
 
 export abstract class VoteAPI extends API {

--- a/src/core/vote.ts
+++ b/src/core/vote.ts
@@ -75,6 +75,7 @@ export abstract class VoteCore extends TransactionCore {
         nonce: new Uint8Array(nonce),
         votePackage: new Uint8Array(generatedVotePackage ?? votePackage),
         encryptionKeyIndexes: keyIndexes || [],
+        memo: vote.memo ? new Uint8Array(Buffer.from(vote.memo, 'utf8')) : undefined,
       };
     } catch (error) {
       throw new Error('The poll vote envelope could not be generated');

--- a/src/services/csp.ts
+++ b/src/services/csp.ts
@@ -77,6 +77,9 @@ export class CspService extends Service implements CspServiceProperties {
   }
 
   static cspVote(vote: Vote, signature: string, proof_type?: CspProofType): CspVote {
-    return new CspVote(vote.votes, signature, proof_type);
+    const cspVote = new CspVote(vote.votes, signature, proof_type);
+    // Carry over anything set on the original vote that is not census specific
+    cspVote.memo = vote.memo;
+    return cspVote;
   }
 }

--- a/src/types/vote/anonymous.ts
+++ b/src/types/vote/anonymous.ts
@@ -10,9 +10,11 @@ export class AnonymousVote extends Vote {
    * @param votes - The list of votes values
    * @param signature - The signature of the payload
    * @param password - The password of the anonymous vote
+   * @param memo - Optional free-text note attached by the voter (max 256 bytes when UTF-8 encoded).
+   *   Note it is neither signed nor covered by the zk proof on anonymous elections, see {@link Vote.memo}
    */
-  public constructor(votes: Array<number | bigint>, signature?: string, password: string = '0') {
-    super(votes);
+  public constructor(votes: Array<number | bigint>, signature?: string, password: string = '0', memo?: string) {
+    super(votes, memo);
     this.password = password;
     this.signature = signature;
   }

--- a/src/types/vote/csp.ts
+++ b/src/types/vote/csp.ts
@@ -13,9 +13,16 @@ export class CspVote extends Vote {
    * @param signature - The CSP signature
    * @param proof -_type The CSP proof type
    * @param weight - The vote weight
+   * @param memo - Optional free-text note attached by the voter (max 256 bytes when UTF-8 encoded)
    */
-  public constructor(votes: Array<number | bigint>, signature: string, proof_type?: CspProofType, weight?: bigint) {
-    super(votes);
+  public constructor(
+    votes: Array<number | bigint>,
+    signature: string,
+    proof_type?: CspProofType,
+    weight?: bigint,
+    memo?: string
+  ) {
+    super(votes, memo);
     this.signature = signature;
     this.proof_type = proof_type;
     this.weight = weight;

--- a/src/types/vote/vote.ts
+++ b/src/types/vote/vote.ts
@@ -3,14 +3,19 @@
  */
 export class Vote {
   private _votes: Array<number | bigint>;
+  private _memo?: string;
+
+  public static MAX_MEMO_BYTES = 256;
 
   /**
    * Constructs a vote
    *
    * @param votes - The list of votes values
+   * @param memo - Optional free-text note attached by the voter (max 256 bytes when UTF-8 encoded)
    */
-  public constructor(votes: Array<number | bigint>) {
+  public constructor(votes: Array<number | bigint>, memo?: string) {
     this.votes = votes;
+    this.memo = memo;
   }
 
   get votes(): Array<number | bigint> {
@@ -19,5 +24,16 @@ export class Vote {
 
   set votes(value: Array<number | bigint>) {
     this._votes = value;
+  }
+
+  get memo(): string {
+    return this._memo;
+  }
+
+  set memo(value: string) {
+    if (value && new TextEncoder().encode(value).length > Vote.MAX_MEMO_BYTES) {
+      throw new Error('Memo cannot be longer than ' + Vote.MAX_MEMO_BYTES + ' bytes');
+    }
+    this._memo = value;
   }
 }

--- a/src/types/vote/vote.ts
+++ b/src/types/vote/vote.ts
@@ -42,11 +42,11 @@ export class Vote {
    *
    * An empty memo is normalized to `undefined`, matching how the chain stores it.
    */
-  get memo(): string {
+  get memo(): string | undefined {
     return this._memo;
   }
 
-  set memo(value: string) {
+  set memo(value: string | undefined) {
     if (value && Buffer.byteLength(value, 'utf8') > Vote.MAX_MEMO_BYTES) {
       throw new Error('Memo cannot be longer than ' + Vote.MAX_MEMO_BYTES + ' bytes');
     }

--- a/src/types/vote/vote.ts
+++ b/src/types/vote/vote.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 /**
  * Represents a vote
  */
@@ -5,7 +7,7 @@ export class Vote {
   private _votes: Array<number | bigint>;
   private _memo?: string;
 
-  public static MAX_MEMO_BYTES = 256;
+  public static readonly MAX_MEMO_BYTES = 256;
 
   /**
    * Constructs a vote
@@ -26,14 +28,28 @@ export class Vote {
     this._votes = value;
   }
 
+  /**
+   * Optional free-text note attached by the voter, e.g. an open "Other" answer.
+   *
+   * Two caveats worth knowing before relying on it:
+   *
+   * - The memo is gated behind a soft fork on the chain side. Until it activates
+   *   for the target chain, the memo is silently ignored: it is not stored, not
+   *   hashed into the vote and not returned by the API.
+   * - On anonymous elections the vote transaction is not signed and the memo is
+   *   not covered by the zk proof, so it can be altered in transit. Free text
+   *   also weakens the anonymity set. Do not put anything sensitive in it.
+   *
+   * An empty memo is normalized to `undefined`, matching how the chain stores it.
+   */
   get memo(): string {
     return this._memo;
   }
 
   set memo(value: string) {
-    if (value && new TextEncoder().encode(value).length > Vote.MAX_MEMO_BYTES) {
+    if (value && Buffer.byteLength(value, 'utf8') > Vote.MAX_MEMO_BYTES) {
       throw new Error('Memo cannot be longer than ' + Vote.MAX_MEMO_BYTES + ' bytes');
     }
-    this._memo = value;
+    this._memo = value || undefined;
   }
 }

--- a/test/unit/types/core/vote.test.ts
+++ b/test/unit/types/core/vote.test.ts
@@ -1,0 +1,53 @@
+import { Tx } from '@vocdoni/proto/vochain';
+import { Buffer } from 'buffer';
+import { CensusType, CspService, PublishedElection, Vote } from '../../../../src';
+import { CensusProof } from '../../../../src/services';
+import { VoteCore } from '../../../../src/core/vote';
+
+const electionId = '43cbda11b9d1a322c03eac325eb8a7b72779b46a76f8a727cff94b539ed9b903';
+
+// generateVoteTransaction only reads the identifier and the census type off the election
+const election = {
+  id: electionId,
+  census: { type: CensusType.WEIGHTED },
+} as unknown as PublishedElection;
+
+const censusProof: CensusProof = {
+  type: CensusType.WEIGHTED,
+  weight: '1',
+  root: electionId,
+  proof: 'deadbeef',
+  value: '01',
+};
+
+const decodeMemo = (tx: Uint8Array): string => {
+  const decoded = Tx.decode(tx);
+  if (decoded.payload?.$case !== 'vote') {
+    throw new Error('The decoded transaction is not a vote');
+  }
+  const memo = decoded.payload.vote.memo;
+  return memo ? Buffer.from(memo).toString('utf8') : undefined;
+};
+
+describe('Vote core tests', () => {
+  it('should encode the memo into the vote envelope', () => {
+    const { tx } = VoteCore.generateVoteTransaction(election, censusProof, new Vote([1], 'free-text note'));
+    expect(decodeMemo(tx)).toEqual('free-text note');
+  });
+  it('should roundtrip a multibyte memo verbatim', () => {
+    const memo = 'Otro: ñandú 🗳 ✓';
+    const { tx } = VoteCore.generateVoteTransaction(election, censusProof, new Vote([1], memo));
+    expect(decodeMemo(tx)).toEqual(memo);
+  });
+  it('should omit the memo when the vote carries none', () => {
+    const { tx } = VoteCore.generateVoteTransaction(election, censusProof, new Vote([1]));
+    expect(decodeMemo(tx)).toBeUndefined();
+    const empty = VoteCore.generateVoteTransaction(election, censusProof, new Vote([1], ''));
+    expect(decodeMemo(empty.tx)).toBeUndefined();
+  });
+  it('should keep the memo when building a csp vote out of a plain vote', () => {
+    const cspVote = CspService.cspVote(new Vote([1], 'csp note'), 'signature');
+    expect(cspVote.memo).toEqual('csp note');
+    expect(cspVote.votes).toEqual([1]);
+  });
+});

--- a/test/unit/types/vote.test.ts
+++ b/test/unit/types/vote.test.ts
@@ -1,0 +1,25 @@
+import { Vote } from '../../../src';
+
+describe('Vote tests', () => {
+  it('should have the correct type', () => {
+    const vote = new Vote([1, 2, 3]);
+    expect(vote).toBeInstanceOf(Vote);
+    expect(vote.votes).toEqual([1, 2, 3]);
+    expect(vote.memo).toBeUndefined();
+  });
+  it('should accept a memo', () => {
+    const vote = new Vote([1], 'free-text note');
+    expect(vote.memo).toEqual('free-text note');
+    vote.memo = 'changed';
+    expect(vote.memo).toEqual('changed');
+  });
+  it('should accept a memo of up to 256 bytes', () => {
+    const vote = new Vote([1], 'a'.repeat(256));
+    expect(vote.memo).toHaveLength(256);
+  });
+  it('should throw when the memo is longer than 256 bytes', () => {
+    expect(() => new Vote([1], 'a'.repeat(257))).toThrow('Memo cannot be longer than 256 bytes');
+    // multibyte characters count as their UTF-8 encoded size
+    expect(() => new Vote([1], '€'.repeat(86))).toThrow('Memo cannot be longer than 256 bytes');
+  });
+});

--- a/test/unit/types/vote.test.ts
+++ b/test/unit/types/vote.test.ts
@@ -1,4 +1,4 @@
-import { Vote } from '../../../src';
+import { AnonymousVote, CspVote, Vote } from '../../../src';
 
 describe('Vote tests', () => {
   it('should have the correct type', () => {
@@ -21,5 +21,23 @@ describe('Vote tests', () => {
     expect(() => new Vote([1], 'a'.repeat(257))).toThrow('Memo cannot be longer than 256 bytes');
     // multibyte characters count as their UTF-8 encoded size
     expect(() => new Vote([1], '€'.repeat(86))).toThrow('Memo cannot be longer than 256 bytes');
+  });
+  it('should normalize an empty memo to undefined', () => {
+    expect(new Vote([1], '').memo).toBeUndefined();
+    const vote = new Vote([1], 'something');
+    vote.memo = '';
+    expect(vote.memo).toBeUndefined();
+  });
+  it('should accept a memo on an anonymous vote', () => {
+    const vote = new AnonymousVote([1], 'signature', '0', 'anon note');
+    expect(vote).toBeInstanceOf(Vote);
+    expect(vote.memo).toEqual('anon note');
+    expect(new AnonymousVote([1], 'signature').memo).toBeUndefined();
+  });
+  it('should accept a memo on a csp vote', () => {
+    const vote = new CspVote([1], 'signature', undefined, undefined, 'csp note');
+    expect(vote).toBeInstanceOf(Vote);
+    expect(vote.memo).toEqual('csp note');
+    expect(new CspVote([1], 'signature').memo).toBeUndefined();
   });
 });


### PR DESCRIPTION
This is Claude (Fable 5) speaking on behalf of elboletaire.

## What

- **build:** upgrade `@vocdoni/proto` from 1.15.12 to 1.15.13.
- **feat:** allow attaching a `memo` to votes, using the new optional `memo` field on `VoteEnvelope` introduced in proto 1.15.13.

## Details

The only API change between proto 1.15.12 and 1.15.13 (verified by diffing both published tarballs) is the new optional `memo?: Uint8Array` field on `VoteEnvelope` — a voter-attached free-text note, max 256 bytes, with UTF-8/size validation delegated to the app layer.

On the SDK side:

- `Vote` accepts an optional `memo` as second constructor argument (also settable via the `memo` property, inherited by `AnonymousVote` and `CspVote`). The setter rejects memos over 256 UTF-8 bytes.
- `VoteCore.prepareVoteData` encodes the memo into the vote envelope, covering all voting paths (weighted, anonymous, CSP).
- The API-mirror `VoteEnvelope` interface in `src/api/chain/transactions.ts` gained the optional `memo` field.
- New unit tests for the memo getter/setter and the 256-byte limit (including multibyte characters).

## Verification

- `yarn build` ✔
- `yarn test:unit` ✔ (11 suites, 58 tests)
- `yarn lint` ✔
- Memo verified to survive an encode/decode roundtrip through `Tx`/`VoteEnvelope`.

Note: the 256-byte limit is enforced client-side per the proto field docs; acceptance by deployed Vochain nodes hasn't been integration-tested here.