### PR TITLE
feat: resolve election metadata stored outside IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,29 @@ You can also fetch all the elections created for a given account using `fetchEle
 })();
 ~~~
 
+#### Metadata stored outside IPFS
+
+The API only resolves `ipfs://` metadata URIs, so elections publishing their metadata
+elsewhere (like the ones created through the Vocdoni SaaS) come back with no metadata at
+all. The SDK resolves those documents itself, best effort: an unreachable one leaves you
+with the same metadata-less election you would have gotten anyway, never with an error.
+
+Since metadata URIs come from the chain, only the hosts you trust are requested. The
+defaults cover the Vocdoni infrastructure, and self hosted deployments can extend them:
+
+~~~ts
+const client = new VocdoniSDKClient({
+  env: EnvOptions.PROD,
+  metadata: {
+    allowed_hosts: ['vocdoni.io', 'vocdoni.net', 'storage.example.com'], // `['*']` allows any host, `[]` disables resolution
+    timeout: 5000, // ms to wait for a metadata document
+    max_size: 1024 * 1024, // maximum accepted document size, in bytes
+  },
+})
+~~~
+
+Hosts match themselves and their subdomains, and only `https://` URIs are ever requested.
+
 ### Changing election status
 
 See the [Election lifecycle states][election-lifecycle-states] details for more information

--- a/src/api/election.ts
+++ b/src/api/election.ts
@@ -233,9 +233,13 @@ export interface IElectionInfoResponse {
   tallyMode: ITallyMode;
 
   /**
-   * The metadata of the election (can be encrypted)
+   * The metadata of the election (can be encrypted).
+   *
+   * Absent when the API could not resolve it: the node only resolves `ipfs://`
+   * metadata URIs, so elections publishing their metadata elsewhere come back
+   * without this key.
    */
-  metadata: ElectionMetadata | string;
+  metadata?: ElectionMetadata | string;
 }
 
 export interface IEncryptionKey {

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -33,4 +33,20 @@ export abstract class FileAPI extends API {
       .then((response) => response.data)
       .catch(this.isApiError);
   }
+
+  /**
+   * Fetches a document from an arbitrary location.
+   *
+   * Unlike the rest of the API methods this one does not talk to the vocdoni
+   * API, so its errors are not mapped to SDK errors: callers are expected to
+   * treat any rejection as "the document is not available".
+   *
+   * @param url - Absolute URL of the document
+   * @param timeout - Milliseconds to wait before giving up
+   * @param maxSize - Maximum accepted response size, in bytes
+   * @returns The parsed response body
+   */
+  public static fetch(url: string, timeout: number, maxSize: number): Promise<any> {
+    return axios.get(url, { timeout, maxContentLength: maxSize }).then((response) => response.data);
+  }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,6 +57,7 @@ import {
   FaucetService,
   FetchElectionsParametersWithPagination,
   FileService,
+  MetadataOptions,
   VoteService,
   VoteSteps,
   VoteStepValue,
@@ -105,6 +106,7 @@ type CensusOptions = {
  * @property {Wallet | Signer | RemoteSigner | null} wallet `Wallet` or `Signer` object from `ethersproject` library
  * @property {string | null} electionId Required by other methods like `submitVote` or `createElection`.
  * @property {FaucetOptions | null} faucet Specify custom Faucet options
+ * @property {MetadataOptions | null} metadata Specify how metadata stored outside IPFS is resolved
  */
 export type ClientOptions = {
   env: EnvOptions;
@@ -114,6 +116,7 @@ export type ClientOptions = {
   faucet?: Partial<FaucetOptions>;
   tx_wait?: TxWaitOptions;
   census?: CensusOptions;
+  metadata?: MetadataOptions;
 };
 
 /**
@@ -159,7 +162,7 @@ export class VocdoniSDKClient {
       chunk_size: opts.census?.chunk ?? CENSUS_CHUNK_SIZE,
       async: { async: opts.census?.async ?? CENSUS_ASYNC, wait: opts.census?.wait_time ?? CENSUS_ASYNC_WAIT_TIME },
     });
-    this.fileService = new FileService({ url: this.url });
+    this.fileService = new FileService({ url: this.url, metadata: opts.metadata });
     this.chainService = new ChainService({
       url: this.url,
       txWait: {
@@ -176,6 +179,7 @@ export class VocdoniSDKClient {
       url: this.url,
       censusService: this.censusService,
       chainService: this.chainService,
+      fileService: this.fileService,
     });
     this.voteService = new VoteService({
       url: this.url,

--- a/src/services/election.ts
+++ b/src/services/election.ts
@@ -20,6 +20,7 @@ import {
   PaginationResponse,
 } from '../api';
 import { CensusService } from './census';
+import { FileService } from './file';
 import { allSettled } from '../util/promise';
 import invariant from 'tiny-invariant';
 import { ElectionCore } from '../core/election';
@@ -33,6 +34,7 @@ import { Asymmetric } from '../util/encryption';
 interface ElectionServiceProperties {
   censusService: CensusService;
   chainService: ChainService;
+  fileService: FileService;
 }
 
 type ElectionServiceParameters = ServiceProperties & ElectionServiceProperties;
@@ -78,6 +80,7 @@ export type ElectionCreationStepValue =
 export class ElectionService extends Service implements ElectionServiceProperties {
   public censusService: CensusService;
   public chainService: ChainService;
+  public fileService: FileService;
 
   /**
    * Instantiate the election service.
@@ -87,6 +90,8 @@ export class ElectionService extends Service implements ElectionServicePropertie
   constructor(params: Partial<ElectionServiceParameters>) {
     super();
     Object.assign(this, params);
+    // metadata resolution has to work regardless of how the service was built
+    this.fileService = this.fileService ?? new FileService({ url: this.url });
   }
 
   public async signTransaction(
@@ -124,6 +129,31 @@ export class ElectionService extends Service implements ElectionServicePropertie
       return Promise.resolve(new CspCensus(electionInfo.census.censusRoot, electionInfo.census.censusURL));
     }
     return this.buildPublishedCensus(electionInfo);
+  }
+
+  /**
+   * Resolves the election metadata when the API could not inline it.
+   *
+   * The node only resolves `ipfs://` metadata URIs, so elections publishing
+   * their metadata elsewhere come back with no `metadata` key at all. Fetching
+   * it here saves every consumer from having to deal with a metadata-less
+   * election on its own.
+   *
+   * Never rejects: an unresolvable document leaves the election info untouched.
+   *
+   * @param electionInfo - The election information, as returned by the API
+   */
+  async resolveMetadata(electionInfo) {
+    if (electionInfo.metadata || !electionInfo.metadataURL) {
+      return electionInfo;
+    }
+
+    const metadata = await this.fileService.fetchMetadata(electionInfo.metadataURL);
+    if (metadata) {
+      electionInfo.metadata = metadata;
+    }
+
+    return electionInfo;
   }
 
   decryptMetadata(electionInfo, password) {
@@ -173,6 +203,8 @@ export class ElectionService extends Service implements ElectionServicePropertie
       throw err;
     });
 
+    await this.resolveMetadata(electionInformation);
+
     let electionInfo, census;
     try {
       electionInfo = this.decryptMetadata(electionInformation, password);
@@ -191,8 +223,8 @@ export class ElectionService extends Service implements ElectionServicePropertie
       organizationId: electionInfo.organizationId,
       title: electionInfo.metadata?.title,
       description: electionInfo.metadata?.description,
-      header: electionInfo.metadata?.media.header,
-      streamUri: electionInfo.metadata?.media.streamUri,
+      header: electionInfo.metadata?.media?.header,
+      streamUri: electionInfo.metadata?.media?.streamUri,
       meta: electionInfo.metadata?.meta,
       startDate: electionInfo.startDate,
       endDate: electionInfo.endDate,
@@ -225,14 +257,14 @@ export class ElectionService extends Service implements ElectionServicePropertie
         maxValue: electionInfo.tallyMode.maxValue,
         maxTotalCost: electionInfo.tallyMode.maxTotalCost,
       },
-      questions: electionInfo.metadata?.questions.map((question, qIndex) => ({
+      questions: electionInfo.metadata?.questions?.map((question, qIndex) => ({
         title: question.title,
         description: question.description,
         numAbstains: this.calculateMultichoiceAbstains(electionInfo.metadata.type, electionInfo.result),
         choices: question.choices.map((choice, cIndex) => ({
           title: choice.title,
           value: choice.value,
-          results: this.calculateChoiceResults(electionInfo.metadata.type.name, electionInfo.result, qIndex, cIndex),
+          results: this.calculateChoiceResults(electionInfo.metadata.type?.name, electionInfo.result, qIndex, cIndex),
           ...(choice.meta && { meta: choice.meta }),
         })),
         ...(question.meta && { meta: question.meta }),

--- a/src/services/file.ts
+++ b/src/services/file.ts
@@ -2,12 +2,36 @@ import { Service, ServiceProperties } from './service';
 import { FileAPI } from '../api';
 import invariant from 'tiny-invariant';
 import { Buffer } from 'buffer';
+import { ElectionMetadata } from '../types';
+import { METADATA_ALLOWED_HOSTS, METADATA_FETCH_TIMEOUT, METADATA_MAX_SIZE } from '../util/constants';
 
-interface FileServiceProperties {}
+/**
+ * Policy applied when resolving metadata documents which are not stored on
+ * IPFS (and are therefore not resolved by the API itself).
+ *
+ * @typedef MetadataOptions
+ * @property {string[] | null} allowed_hosts Hosts allowed to serve metadata documents. Subdomains of the listed hosts
+ * are allowed too, `['*']` allows any host and `[]` disables remote resolution entirely.
+ * @property {number | null} timeout Milliseconds to wait for a metadata document before giving up
+ * @property {number | null} max_size Maximum accepted metadata document size, in bytes
+ */
+export type MetadataOptions = {
+  allowed_hosts?: string[];
+  timeout?: number;
+  max_size?: number;
+};
+
+interface FileServiceProperties {
+  metadata: MetadataOptions;
+}
 
 type FileServiceParameters = ServiceProperties & FileServiceProperties;
 
 export class FileService extends Service implements FileServiceProperties {
+  public metadata: MetadataOptions;
+
+  private readonly metadataCache: Map<string, Promise<ElectionMetadata | null>> = new Map();
+
   /**
    * Instantiate the election service.
    *
@@ -16,6 +40,11 @@ export class FileService extends Service implements FileServiceProperties {
   constructor(params: Partial<FileServiceParameters>) {
     super();
     Object.assign(this, params);
+    this.metadata = {
+      allowed_hosts: this.metadata?.allowed_hosts ?? METADATA_ALLOWED_HOSTS,
+      timeout: this.metadata?.timeout ?? METADATA_FETCH_TIMEOUT,
+      max_size: this.metadata?.max_size ?? METADATA_MAX_SIZE,
+    };
   }
 
   /**
@@ -28,5 +57,86 @@ export class FileService extends Service implements FileServiceProperties {
     invariant(this.url, 'No URL set');
     const b64Data = Buffer.from(data, 'utf8').toString('base64');
     return FileAPI.cid(this.url, b64Data).then((response) => response.cid);
+  }
+
+  /**
+   * Tells whether the SDK is willing to resolve the given metadata URI itself.
+   *
+   * Only `https://` URIs served by an allowed host qualify: `ipfs://` URIs are
+   * already resolved by the API, and metadata URIs come from the chain, so any
+   * other location is a request we don't want to make on the consumer behalf.
+   *
+   * @param uri - The metadata URI, as reported by the API
+   */
+  isResolvableMetadataUrl(uri: string): boolean {
+    if (!uri) return false;
+
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch (_) {
+      return false;
+    }
+
+    if (parsed.protocol !== 'https:') return false;
+
+    const host = parsed.hostname.toLowerCase();
+
+    return this.metadata.allowed_hosts.some((allowed) => {
+      if (allowed === '*') return true;
+      const allowedHost = allowed.toLowerCase();
+      return host === allowedHost || host.endsWith('.' + allowedHost);
+    });
+  }
+
+  /**
+   * Fetches an election metadata document stored outside IPFS.
+   *
+   * Resolution is best effort: any failure (disallowed host, timeout, network
+   * or CORS error, malformed payload) resolves to `null` rather than rejecting,
+   * so an unreachable document degrades the resulting election instead of
+   * breaking it.
+   *
+   * Successful resolutions are cached in memory by URI, since elections are
+   * usually fetched in batches.
+   *
+   * @param uri - The metadata URI, as reported by the API
+   * @returns The metadata document, or null when it could not be resolved
+   */
+  fetchMetadata(uri: string): Promise<ElectionMetadata | null> {
+    if (!this.isResolvableMetadataUrl(uri)) return Promise.resolve(null);
+    if (this.metadataCache.has(uri)) return this.metadataCache.get(uri);
+
+    const request = FileAPI.fetch(uri, this.metadata.timeout, this.metadata.max_size)
+      .then((data) => FileService.normalizeMetadata(data))
+      .catch(() => null)
+      .then((metadata) => {
+        // remembering a failure would turn a transient error into a permanent
+        // one for the whole lifetime of the client
+        if (metadata === null) this.metadataCache.delete(uri);
+        return metadata;
+      });
+
+    this.metadataCache.set(uri, request);
+
+    return request;
+  }
+
+  /**
+   * Shapes a freshly fetched document into something the rest of the SDK can
+   * safely read, discarding anything which is not metadata shaped.
+   *
+   * Anything but a plain object is dropped: a host answering with an error page
+   * or a bare string is telling us it has no metadata to serve, and attaching
+   * that to the election would be worse than leaving it empty.
+   *
+   * @param data - The fetched document
+   */
+  private static normalizeMetadata(data: any): ElectionMetadata | null {
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) return null;
+
+    // `media` is optional for everyone producing metadata but not for everyone
+    // reading it, so make sure it is always there
+    return { ...data, media: data.media ?? {} } as ElectionMetadata;
   }
 }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -47,6 +47,20 @@ export const CENSUS_CHUNK_SIZE = 8192;
 export const CENSUS_ASYNC = true;
 export const CENSUS_ASYNC_WAIT_TIME = 5000;
 
+/**
+ * Hosts allowed to serve election metadata documents which are not stored on
+ * IPFS. Entries match the host itself and any of its subdomains, and the `*`
+ * entry matches everything.
+ *
+ * Metadata URIs come from the chain and are therefore attacker influenceable,
+ * so the SDK only requests the ones served by a host the consumer trusts. Self
+ * hosted deployments are expected to extend this list through the `metadata`
+ * client option.
+ */
+export const METADATA_ALLOWED_HOSTS = ['vocdoni.io', 'vocdoni.net'];
+export const METADATA_FETCH_TIMEOUT = 5000;
+export const METADATA_MAX_SIZE = 1024 * 1024;
+
 export enum TxMessage {
   REGISTER_SIK = 'You are signing a Vocdoni transaction of type REGISTER_SIK for secret identity key {sik}.\n\nThe hash of this transaction is {hash} and the destination chain is {chainId}.',
   SET_ACCOUNT = 'You are signing a Vocdoni transaction of type SET_ACCOUNT/{type}.\n\nThe hash of this transaction is {hash} and the destination chain is {chainId}.',

--- a/test/unit/services/election.test.ts
+++ b/test/unit/services/election.test.ts
@@ -1,0 +1,183 @@
+import axios from 'axios';
+import {
+  CensusService,
+  ElectionAPI,
+  ElectionResultsTypeNames,
+  ElectionService,
+  ElectionStatus,
+  FileService,
+} from '../../../src';
+
+const URL = 'https://api.vocdoni.io/v2';
+const IPFS_URL = 'ipfs://bafybeieh4gpvvpvbclcs2yjyfg3nx4nxg6f2ottrfnhpdrdvzzuxozzhqe';
+const REMOTE_URL = 'https://saas-api-stg.vocdoni.net/storage/f7d0a0a1.json';
+
+const metadata = (overrides = {}) => ({
+  version: '1.0',
+  title: { default: 'A remotely stored election' },
+  description: { default: 'Its metadata never reached the chain' },
+  media: {},
+  questions: [
+    {
+      title: { default: 'Question' },
+      description: { default: 'Description' },
+      choices: [
+        { title: { default: 'Yes' }, value: 0 },
+        { title: { default: 'No' }, value: 1 },
+      ],
+    },
+  ],
+  type: { name: ElectionResultsTypeNames.SINGLE_CHOICE_MULTIQUESTION, properties: null },
+  ...overrides,
+});
+
+// an election info response as returned for a process whose metadata the node
+// could not resolve: everything but the `metadata` key
+const electionInfo = (overrides = {}) => ({
+  electionId: '6b342d99f2188f71faa8771d4aaddcde1066d8e4486b677e928e030000000010',
+  organizationId: '6b342d99f2188f71faa8771d4aaddcde1066d8e4',
+  status: ElectionStatus.RESULTS,
+  startDate: '2026-01-01T00:00:00.000Z',
+  endDate: '2026-01-08T00:00:00.000Z',
+  voteCount: 3,
+  finalResults: true,
+  result: [['1', '2']],
+  manuallyEnded: false,
+  chainId: 'vocdoni-stage-11',
+  census: {
+    censusOrigin: 'OFF_CHAIN_TREE_WEIGHTED',
+    censusRoot: 'a3bd4ee45cbbd8ee45cbbd8e5cbbd8ee45cbbd8ee45cbbd8ee45cbbd8ee45cbbd',
+    postRegisterCensusRoot: '',
+    censusURL: 'https://api.vocdoni.io/v2/censuses/a3bd/export',
+    maxCensusSize: 10,
+  },
+  metadataURL: REMOTE_URL,
+  creationTime: '2025-12-31T00:00:00.000Z',
+  voteMode: { serial: false, anonymous: false, encryptedVotes: false, uniqueValues: false, costFromWeight: false },
+  electionMode: { interruptible: true, dynamicCensus: false, encryptedMetaData: false, preRegister: false },
+  tallyMode: { maxCount: 1, maxValue: 1, maxVoteOverwrites: 0, maxTotalCost: 0, costExponent: 10000 },
+  ...overrides,
+});
+
+// the census is fetched over the network and is irrelevant here: `fetchElection`
+// already tolerates it failing
+const censusService = { get: () => Promise.reject(new Error('no census service')) } as unknown as CensusService;
+
+const service = () => new ElectionService({ url: URL, censusService });
+
+let info: jest.SpyInstance;
+let get: jest.SpyInstance;
+
+beforeEach(() => {
+  info = jest.spyOn(ElectionAPI, 'info');
+  get = jest.spyOn(axios, 'get');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('Election Service metadata resolution tests', () => {
+  it('should build its own file service when none is given', () => {
+    expect(service().fileService).toBeInstanceOf(FileService);
+
+    const fileService = new FileService({ url: URL });
+    expect(new ElectionService({ url: URL, censusService, fileService }).fileService).toBe(fileService);
+  });
+  it('should resolve the metadata when the api did not inline it', async () => {
+    info.mockResolvedValue(electionInfo());
+    get.mockResolvedValue({ data: metadata() });
+
+    const election = await service().fetchElection('6b34');
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(election.title).toEqual({ default: 'A remotely stored election' });
+    expect(election.description).toEqual({ default: 'Its metadata never reached the chain' });
+    expect(election.resultsType.name).toEqual(ElectionResultsTypeNames.SINGLE_CHOICE_MULTIQUESTION);
+    expect(election.questions).toHaveLength(1);
+    expect(election.questions[0].choices.map((choice) => choice.results)).toEqual(['1', '2']);
+    // the resolved document is part of the raw response too
+    expect(election.raw['metadata']).toEqual(metadata());
+  });
+  it('should not fetch anything when the api inlined the metadata', async () => {
+    info.mockResolvedValue(electionInfo({ metadataURL: IPFS_URL, metadata: metadata() }));
+
+    const election = await service().fetchElection('6b34');
+
+    expect(get).not.toHaveBeenCalled();
+    expect(election.title).toEqual({ default: 'A remotely stored election' });
+  });
+  it('should not fetch anything for an ipfs metadata url', async () => {
+    info.mockResolvedValue(electionInfo({ metadataURL: IPFS_URL }));
+
+    const election = await service().fetchElection('6b34');
+
+    expect(get).not.toHaveBeenCalled();
+    expect(election.title).toBeUndefined();
+    expect(election.questions).toEqual([]);
+  });
+  it('should not fetch anything for an empty metadata url', async () => {
+    info.mockResolvedValue(electionInfo({ metadataURL: '' }));
+
+    await service().fetchElection('6b34');
+
+    expect(get).not.toHaveBeenCalled();
+  });
+  it('should not fetch anything for a host which is not allowed', async () => {
+    info.mockResolvedValue(electionInfo({ metadataURL: 'https://evil.example/storage/f7d0a0a1.json' }));
+
+    const election = await service().fetchElection('6b34');
+
+    expect(get).not.toHaveBeenCalled();
+    expect(election.title).toBeUndefined();
+  });
+  it('should leave the election info untouched when the fetch fails', async () => {
+    info.mockResolvedValue(electionInfo());
+    get.mockRejectedValue(new Error('timeout of 5000ms exceeded'));
+
+    const election = await service().fetchElection('6b34');
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(election.id).toEqual('6b342d99f2188f71faa8771d4aaddcde1066d8e4486b677e928e030000000010');
+    expect(election.title).toBeUndefined();
+    expect(election.resultsType).toBeUndefined();
+    expect(election.questions).toEqual([]);
+    expect(election.raw['metadata']).toBeUndefined();
+  });
+  it('should not throw for a metadata document with no media', async () => {
+    const { media, ...noMedia } = metadata();
+    expect(media).toBeDefined();
+    info.mockResolvedValue(electionInfo());
+    get.mockResolvedValue({ data: noMedia });
+
+    const election = await service().fetchElection('6b34');
+
+    expect(election.header).toBeUndefined();
+    expect(election.streamUri).toBeUndefined();
+    expect(election.title).toEqual({ default: 'A remotely stored election' });
+  });
+  it('should not throw for a metadata document with no type nor questions', async () => {
+    const { type, questions, ...partial } = metadata();
+    expect(type).toBeDefined();
+    expect(questions).toBeDefined();
+    info.mockResolvedValue(electionInfo());
+    get.mockResolvedValue({ data: partial });
+
+    const election = await service().fetchElection('6b34');
+
+    expect(election.title).toEqual({ default: 'A remotely stored election' });
+    expect(election.resultsType).toBeUndefined();
+    expect(election.questions).toEqual([]);
+  });
+  it('should resolve each metadata url only once', async () => {
+    info.mockResolvedValue(electionInfo());
+    get.mockResolvedValue({ data: metadata() });
+    const electionService = service();
+
+    await Promise.all([electionService.fetchElection('6b34'), electionService.fetchElection('6b34')]);
+    await electionService.fetchElection('6b34');
+
+    expect(info).toHaveBeenCalledTimes(3);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/services/file.test.ts
+++ b/test/unit/services/file.test.ts
@@ -1,0 +1,144 @@
+import axios from 'axios';
+import { FileService } from '../../../src';
+import { METADATA_FETCH_TIMEOUT, METADATA_MAX_SIZE } from '../../../src/util/constants';
+
+const IPFS_URL = 'ipfs://bafybeieh4gpvvpvbclcs2yjyfg3nx4nxg6f2ottrfnhpdrdvzzuxozzhqe';
+const REMOTE_URL = 'https://saas-api-stg.vocdoni.net/storage/f7d0a0a1.json';
+
+const metadata = () => ({
+  version: '1.0',
+  title: { default: 'A remotely stored election' },
+  description: { default: 'Its metadata never reached the chain' },
+  media: {},
+  questions: [
+    {
+      title: { default: 'Question' },
+      description: { default: 'Description' },
+      choices: [
+        { title: { default: 'Yes' }, value: 0 },
+        { title: { default: 'No' }, value: 1 },
+      ],
+    },
+  ],
+  type: { name: 'single-choice-multiquestion', properties: null },
+});
+
+let get: jest.SpyInstance;
+
+beforeEach(() => {
+  get = jest.spyOn(axios, 'get');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('File Service tests', () => {
+  it('should have the correct type and properties', () => {
+    const service = new FileService({});
+    expect(service).toBeInstanceOf(FileService);
+    expect(service.url).toBeUndefined();
+    expect(service.metadata).toEqual({
+      allowed_hosts: ['vocdoni.io', 'vocdoni.net'],
+      timeout: METADATA_FETCH_TIMEOUT,
+      max_size: METADATA_MAX_SIZE,
+    });
+  });
+  it('should only override the given metadata options', () => {
+    const service = new FileService({ metadata: { timeout: 1000 } });
+    expect(service.metadata.timeout).toEqual(1000);
+    expect(service.metadata.allowed_hosts).toEqual(['vocdoni.io', 'vocdoni.net']);
+    expect(service.metadata.max_size).toEqual(METADATA_MAX_SIZE);
+  });
+  it('should only consider allowed https urls resolvable', () => {
+    const service = new FileService({});
+    expect(service.isResolvableMetadataUrl(REMOTE_URL)).toBe(true);
+    expect(service.isResolvableMetadataUrl('https://vocdoni.io/metadata.json')).toBe(true);
+    expect(service.isResolvableMetadataUrl('https://API.VOCDONI.IO/metadata.json')).toBe(true);
+    // not https
+    expect(service.isResolvableMetadataUrl(IPFS_URL)).toBe(false);
+    expect(service.isResolvableMetadataUrl('http://saas-api-stg.vocdoni.net/storage/x.json')).toBe(false);
+    // not an allowed host
+    expect(service.isResolvableMetadataUrl('https://evil.example/metadata.json')).toBe(false);
+    expect(service.isResolvableMetadataUrl('https://notvocdoni.io/metadata.json')).toBe(false);
+    expect(service.isResolvableMetadataUrl('https://vocdoni.io.evil.example/metadata.json')).toBe(false);
+    // not an url at all
+    expect(service.isResolvableMetadataUrl('')).toBe(false);
+    expect(service.isResolvableMetadataUrl(null)).toBe(false);
+    expect(service.isResolvableMetadataUrl('not an url')).toBe(false);
+  });
+  it('should honor the configured allowed hosts', () => {
+    const custom = new FileService({ metadata: { allowed_hosts: ['storage.example'] } });
+    expect(custom.isResolvableMetadataUrl('https://storage.example/metadata.json')).toBe(true);
+    expect(custom.isResolvableMetadataUrl(REMOTE_URL)).toBe(false);
+
+    const wildcard = new FileService({ metadata: { allowed_hosts: ['*'] } });
+    expect(wildcard.isResolvableMetadataUrl('https://storage.example/metadata.json')).toBe(true);
+    expect(wildcard.isResolvableMetadataUrl(IPFS_URL)).toBe(false);
+
+    const disabled = new FileService({ metadata: { allowed_hosts: [] } });
+    expect(disabled.isResolvableMetadataUrl(REMOTE_URL)).toBe(false);
+  });
+  it('should fetch an allowed metadata document', async () => {
+    get.mockResolvedValue({ data: metadata() });
+    const service = new FileService({});
+
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toEqual(metadata());
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith(REMOTE_URL, {
+      timeout: METADATA_FETCH_TIMEOUT,
+      maxContentLength: METADATA_MAX_SIZE,
+    });
+  });
+  it('should not fetch anything for non resolvable urls', async () => {
+    const service = new FileService({});
+
+    await expect(service.fetchMetadata(IPFS_URL)).resolves.toBeNull();
+    await expect(service.fetchMetadata('https://evil.example/metadata.json')).resolves.toBeNull();
+    await expect(service.fetchMetadata('')).resolves.toBeNull();
+    expect(get).not.toHaveBeenCalled();
+  });
+  it('should normalize a document with no media', async () => {
+    const { media, ...noMedia } = metadata();
+    expect(media).toBeDefined();
+    get.mockResolvedValue({ data: noMedia });
+
+    await expect(new FileService({}).fetchMetadata(REMOTE_URL)).resolves.toEqual({ ...noMedia, media: {} });
+  });
+  it('should resolve to null on failed or unusable responses', async () => {
+    const service = new FileService({});
+
+    get.mockRejectedValueOnce(new Error('timeout of 5000ms exceeded'));
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toBeNull();
+
+    get.mockResolvedValueOnce({ data: '<!doctype html><html lang="en"></html>' });
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toBeNull();
+
+    get.mockResolvedValueOnce({ data: [] });
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toBeNull();
+
+    get.mockResolvedValueOnce({ data: null });
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toBeNull();
+  });
+  it('should cache successful resolutions', async () => {
+    get.mockResolvedValue({ data: metadata() });
+    const service = new FileService({});
+
+    // concurrent calls share the very same request
+    await Promise.all([service.fetchMetadata(REMOTE_URL), service.fetchMetadata(REMOTE_URL)]);
+    await service.fetchMetadata(REMOTE_URL);
+
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+  it('should not cache failed resolutions', async () => {
+    const service = new FileService({});
+
+    get.mockRejectedValueOnce(new Error('Network Error'));
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toBeNull();
+
+    get.mockResolvedValueOnce({ data: metadata() });
+    await expect(service.fetchMetadata(REMOTE_URL)).resolves.toEqual(metadata());
+
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Claude Opus 5 here, controlled by elboletaire.

## Problem

Processes created by the new Vocdoni SaaS publish their metadata to the SaaS' own HTTP storage instead of IPFS:

| | classic process | SaaS process |
|---|---|---|
| `metadataURL` | `ipfs://bafybei…` | `https://saas-api-stg.vocdoni.net/storage/<id>.json` |
| `metadata` in `/v2/elections/:id` | present | **absent** |

The node only resolves `ipfs://` metadata URIs, so for these processes it omits the `metadata` key entirely. `ElectionService.fetchElection` then builds a `PublishedElection` with `title`, `description` and `resultsType` undefined and `questions: []`, and every consumer breaks in its own way — the explorer's process page crashes outright on `election.resultsType.name`.

**~18 of the 40 most recent elections on `api.vocdoni.io` are already in this state.** The metadata documents themselves are well-formed and standard, and are served with `access-control-allow-origin: *` — they just never arrive.

## What this does

### Resolve the metadata when the node couldn't inline it

`FileService.fetchMetadata(uri)` fetches the document, and `ElectionService` calls it before `decryptMetadata` so all of the existing logic (`calculateChoiceResults`, `buildCensus`, `resultsType`) runs unchanged. We add the missing input, we don't reimplement the transformation.

It is **best effort and never rejects**: a disallowed host, timeout, network/CORS error or non-object payload all resolve to `null`, leaving the election info exactly as it is today. This path must never turn a partially-rendering page into a thrown error, so there is no new error type — an SDK error here would either be swallowed at every call site or would make things worse.

- **Cache** keyed by URI, storing the in-flight *promise* so the `fetchElections` N+1 path dedupes concurrent rows, not just sequential ones. Failed resolutions are evicted so a transient error doesn't become permanent for the client's lifetime.
- **Timeout** 5s, plus a 1 MiB `maxContentLength` so a hostile host can't stream indefinitely.

### Host allowlist — the deliberate policy call

**Default `['vocdoni.io', 'vocdoni.net']`, host-or-subdomain, `https:` only — overridable through a new `metadata` client option.**

`metadataURL` comes from the chain and is attacker-influenceable. The decisive risk isn't the *content* (metadata content is already attacker-controlled via IPFS, and consumers already render it) — it's **the request itself**:

- In Node contexts (SSR, backends, indexers) an attacker-created election turns `fetchElection` into an SSRF primitive against whatever the host can reach.
- In browsers, rendering a list page makes every visitor hit an attacker's server, leaking IP and UA.

Both are new, and neither is visible to the consumer. A *fixed* allowlist would be the wrong call though — it breaks self-hosted SaaS, and the SDK already accepts an arbitrary `api_url`, so hardcoding trust is inconsistent. Making it configurable gets both: safe defaults for everyone, one line for self-hosters.

```ts
const client = new VocdoniSDKClient({
  env: EnvOptions.PROD,
  metadata: {
    allowed_hosts: ['vocdoni.io', 'vocdoni.net', 'storage.example.com'], // `['*']` allows any host, `[]` disables resolution
    timeout: 5000,
    max_size: 1024 * 1024,
  },
})
```

`https:`-only is what blocks the sharpest edge (`http://169.254.169.254/…` and friends), independent of the host list.

Two residual limits worth knowing: an allowlisted host that **redirects** can send us elsewhere (redirects left at the axios default, since the allowlist already means the first host is trusted — and `maxRedirects: 0` is ignored by browsers anyway), and `maxContentLength` is Node-only.

### `IElectionInfoResponse.metadata` is now optional

The type claimed metadata was always present. That lie is why nothing flagged this at compile time in any consumer — the explorer casts `election.raw as IElectionInfoResponse` and `tsc` was happy. One word, highest-value change here.

### Four unguarded dereferences

`metadata?.media.header` was optional on `metadata` but **not** on `media` — a document without `media` throws *inside the SDK*, before any consumer error boundary can help. Same for `media.streamUri`, `questions.map`, and `type.name`.

That last one is subtle: `calculateChoiceResults(metadata.type.name, …)` dereferences at the *argument site*, so the function's internal try/catch never covers it. All four matter more now that we're feeding the SDK third-party documents.

## Verification

`yarn lint` clean · `yarn build` clean · **74/74 unit tests** (20 new) · `test/api` 9/9.

Live against `api.vocdoni.io`, with `axios.get` spied to count requests:

| check | result |
|---|---|
| `6b34…0010` (SaaS) | exactly **1** remote request; `title: {default: "Painan?", en: "Painan?"}`, `resultsType: single-choice-multiquestion`, 1 question — all previously `undefined`/`[]` |
| `6b34…0050` (classic IPFS) | **zero** extra requests — all 4 GETs are `api.vocdoni.io/v2` |
| `fetchElections` page of 20 | 16 remote docs, 16 unique requests, no duplication — and **20/20 elections now have titles** |

New unit tests cover: metadata absent + remote URL → hydrated; absent + `ipfs://` → no fetch; absent + empty URL → no fetch; absent + disallowed host → no fetch; fetch fails → election info untouched, no throw; metadata present → no fetch at all; allowlist accept/reject (including the `vocdoni.io.evil.example` suffix trap); cache hit on concurrent calls; failures *not* cached; documents missing `media` / `type` / `questions`.

## Notes

- One judgement call worth flagging: `fetchMetadata` accepts **only plain objects**. An HTML error page would otherwise be assigned as `metadata`, turning a falsy absence into truthy garbage for anyone checking `if (!metadata)`. The cost is that encrypted remote metadata (a base64 string, never observed in the wild) isn't resolved — but `decryptMetadata` already synthesises its `<redacted>` placeholder there, so nothing regresses.
- No `CHANGELOG.md` entry: it's only ever touched in version-bump commits. Worth adding under `## [Unreleased]` at release time. Note `package.json` is at `0.9.3` while the changelog stops at `0.9.2`.
- `yarn ts-types` fails on this branch — and identically on untouched `main`. Every error is TS 4.8 choking on a modern `@types/node/ffi.d.ts`; zero come from `src/`. Pre-existing.
- The `test/census3` suite fails (9 tests, all `Expected ErrNotFoundCensus / Received ErrAPI`) — the census3 service returning unmapped errors, unrelated to this branch.

## Context

Comes out of an investigation in the explorer repo. This is items #1, #2 and #3 of that plan — the SDK-side fixes. Item #4 (guard `resultsType?.name` in `QuestionsTypeBadge` / `ElectionResults`) belongs in `ui-components`, and item #5 (explorer error boundaries) is being done in parallel.

The real fix is still upstream of all of this: the node resolving `https://` metadata URLs, or the SaaS pinning metadata to IPFS. This makes every SDK consumer work in the meantime, and stays harmless once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
