### PR TITLE
fix(csp): build blind payload and submitted bundle from the same CAbundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `client.cspSign` and `client.cspVote` now accept an optional `weight` parameter for weighted CSP elections. When `weight` is omitted from `cspVote`, it defaults to the weight passed to the preceding `cspSign` call on the same client/CSP service instance; passing a conflicting weight throws instead of silently mismatching the two.
+
+### Fixed
+
+- Fixed weighted CSP blind votes being rejected on-chain: the blind-signed CA bundle (`cspSign`) omitted the vote weight while the submitted bundle (`cspVote`/`submitVote`) included it, so the chain's signature verification always failed for weighted blind votes.
+- `voteWeight` in the CSP `CAbundle` is now encoded as a canonical fixed 8-byte big-endian value instead of a minimal-length encoding, matching what the chain expects for CSP salt derivation. This is a wire-format change: anyone using the non-blind `ECDSA_PIDSALTED` CSP proof type with a signature obtained externally (i.e. not produced by this SDK) needs to re-generate it against the new encoding.
+
 ## [0.9.2] - 2025-02-25
 
 ## [0.9.1] - 2024-09-17

--- a/README.md
+++ b/README.md
@@ -568,6 +568,18 @@ const vote = client.cspVote(new Vote([index % 2]), signature);
 const voteId = await client.submitVote(vote);
 ~~~
 
+For weighted CSP elections, pass the voter's `weight` to `cspSign`. The CSP signs the vote weight along with the
+rest of the bundle, so `cspVote` reuses it automatically — there's no need to pass it twice, and passing a
+different weight to `cspVote` throws:
+
+~~~ts
+// Get the blind signature for a weighted vote
+const signature = await client.cspSign(signer.address, step1.token, weight);
+
+// weight is remembered from the cspSign call above and reused here
+const vote = client.cspVote(new Vote([index % 2]), signature);
+~~~
+
 ## Census3
 
 ### What is Census3?

--- a/src/client.ts
+++ b/src/client.ts
@@ -1093,13 +1093,13 @@ export class VocdoniSDKClient {
     return this.cspService.cspStep(this.electionId, stepNumber, data, authToken);
   }
 
-  async cspSign(address: string, token: string) {
+  async cspSign(address: string, token: string, weight?: bigint) {
     invariant(this.electionId, 'No election id set');
-    return this.cspService.cspSign(this.electionId, address, token);
+    return this.cspService.cspSign(this.electionId, address, token, weight);
   }
 
-  cspVote(vote: Vote, signature: string, proof_type?: CspProofType) {
-    return this.cspService.cspVote(vote, signature, proof_type);
+  cspVote(vote: Vote, signature: string, proof_type?: CspProofType, weight?: bigint) {
+    return this.cspService.cspVote(vote, signature, proof_type, weight);
   }
 
   /**

--- a/src/core/vote.ts
+++ b/src/core/vote.ts
@@ -165,15 +165,24 @@ export abstract class VoteCore extends TransactionCore {
     return CAbundle.fromPartial({
       processId: new Uint8Array(Buffer.from(strip0x(electionId), 'hex')),
       address: new Uint8Array(Buffer.from(strip0x(address), 'hex')),
-      voteWeight: weight
-        ? new Uint8Array(
-            Buffer.from(
-              weight.toString(16).padStart(weight.toString(16).length + (weight.toString(16).length % 2), '0'),
-              'hex'
-            )
-          )
-        : undefined,
+      // `weight == null` also covers `null`, not just `undefined`: only the absence of a weight means
+      // "unweighted". `0n` is a valid weight and must still encode to 8 zero bytes.
+      voteWeight: weight == null ? undefined : this.encodeVoteWeight(weight),
     });
+  }
+
+  /**
+   * Encodes a vote weight in its canonical form: fixed 8-byte big-endian. The chain folds this exact
+   * encoding into the CSP salt derivation (`keccak256(DOMAIN || ProcessId || weightBE8)`), so the
+   * bundle's `voteWeight` must encode the same integer identically.
+   *
+   * @param weight - The vote weight
+   */
+  public static encodeVoteWeight(weight: bigint): Uint8Array {
+    if (typeof weight !== 'bigint' || weight < 0n || weight > 0xffffffffffffffffn) {
+      throw new Error('Vote weight must fit in an unsigned 64 bit integer');
+    }
+    return new Uint8Array(Buffer.from(weight.toString(16).padStart(16, '0'), 'hex'));
   }
 
   public static encodeCspCaBundle(bundle: CAbundle) {

--- a/src/services/csp.ts
+++ b/src/services/csp.ts
@@ -22,6 +22,15 @@ export class CspService extends Service implements CspServiceProperties {
   public info: ICspInfoResponse;
 
   /**
+   * The weight last passed to `cspSign` on this instance (`undefined` if it was signed unweighted),
+   * remembered so the paired `cspVote` call can default to it without the caller having to pass the
+   * weight twice. `undefined` here just means "not yet set"; whether `cspSign` has actually been
+   * called is tracked separately via `signedWeightSet`.
+   */
+  private signedWeight?: bigint;
+  private signedWeightSet = false;
+
+  /**
    * Instantiate the CSP service.
    *
    * @param params - The service parameters
@@ -61,22 +70,59 @@ export class CspService extends Service implements CspServiceProperties {
     );
   }
 
-  async cspSign(electionId: string, address: string, token: string) {
+  /**
+   * Asks the CSP to blind-sign the CA bundle for the given voter.
+   *
+   * For weighted votes, `weight` MUST match the weight submitted with the vote (see `cspVote`):
+   * the chain verifies the CSP signature against the submitted bundle, which includes the weight.
+   * This instance remembers the `weight` it was called with, so the following `cspVote` call on
+   * the same instance does not need to repeat it (see `cspVote` for details).
+   *
+   * @param electionId - The election id
+   * @param address - The voter address
+   * @param token - The token granted by the CSP authentication steps
+   * @param weight - The vote weight attested by the CSP
+   */
+  async cspSign(electionId: string, address: string, token: string, weight?: bigint) {
     invariant(this.url, 'No CSP URL set');
     invariant(this.info, 'No CSP information set');
 
-    const { hexBlinded: blindedPayload, userSecretData } = getBlindedPayload(electionId, token, address);
+    this.signedWeight = weight;
+    this.signedWeightSet = true;
+
+    const { hexBlinded: blindedPayload, userSecretData } = getBlindedPayload(electionId, token, address, weight);
 
     return CspAPI.sign(this.url, electionId, this.info.signatureType[0], blindedPayload, token).then((signature) =>
       CensusBlind.unblind(signature.signature, userSecretData)
     );
   }
 
-  cspVote(vote: Vote, signature: string, proof_type?: CspProofType): CspVote {
-    return CspService.cspVote(vote, signature, proof_type);
+  /**
+   * Builds the `CspVote` to be submitted with the given CSP signature.
+   *
+   * When `weight` is omitted and a preceding `cspSign` call was made on this instance, it defaults
+   * to the weight that was signed for, since the CSP signature is only valid against a bundle built
+   * with that exact weight. Passing a `weight` that conflicts with the one remembered from `cspSign`
+   * throws, rather than silently preferring one of the two values and reintroducing the mismatch
+   * between the blind-signed payload and the submitted bundle.
+   *
+   * @param vote - The vote to be cast
+   * @param signature - The (unblinded) CSP signature
+   * @param proof_type - The CSP proof type
+   * @param weight - The vote weight; defaults to the weight passed to the last `cspSign` call on this instance, if any
+   */
+  cspVote(vote: Vote, signature: string, proof_type?: CspProofType, weight?: bigint): CspVote {
+    if (this.signedWeightSet && weight !== undefined && weight !== this.signedWeight) {
+      throw new Error(
+        `Vote weight (${weight}) does not match the weight signed by the CSP (${this.signedWeight}). ` +
+          'Pass the same weight to cspSign and cspVote, or omit it from cspVote to reuse the signed weight.'
+      );
+    }
+
+    return CspService.cspVote(vote, signature, proof_type, this.signedWeightSet ? this.signedWeight : weight);
   }
 
-  static cspVote(vote: Vote, signature: string, proof_type?: CspProofType): CspVote {
-    return new CspVote(vote.votes, signature, proof_type);
+  static cspVote(vote: Vote, signature: string, proof_type?: CspProofType, weight?: bigint): CspVote {
+    return new CspVote(vote.votes, signature, proof_type, weight);
   }
 }

--- a/src/util/blind-signing.ts
+++ b/src/util/blind-signing.ts
@@ -15,9 +15,21 @@ import {
 } from 'blindsecp256k1';
 import { VoteCore } from '../core/vote';
 
-export function getBlindedPayload(electionId: string, hexTokenR: string, address: string) {
+/**
+ * Blinds the CA bundle payload to be signed by the CSP.
+ *
+ * The weight (if any) MUST be the same one submitted later with the vote: the CSP blind-signs
+ * `keccak256(bundle)` and the chain verifies that signature against the bundle submitted in the
+ * `ProofCA`, so both must be built from the exact same `CAbundle` (including `voteWeight`).
+ *
+ * @param electionId - The election id
+ * @param hexTokenR - The R point provided by the CSP, hex encoded
+ * @param address - The voter address
+ * @param weight - The vote weight attested by the CSP
+ */
+export function getBlindedPayload(electionId: string, hexTokenR: string, address: string, weight?: bigint) {
   const tokenR = CensusBlind.decodePoint(hexTokenR);
-  const caBundle = VoteCore.cspCaBundle(electionId, address);
+  const caBundle = VoteCore.cspCaBundle(electionId, address, weight);
 
   // hash(bundle)
   const hexCaBundle = hexlify(VoteCore.encodeCspCaBundle(caBundle));

--- a/test/unit/services/csp.test.ts
+++ b/test/unit/services/csp.test.ts
@@ -1,0 +1,89 @@
+import { CspProofType, CspService, EnvOptions, ICspInfoResponse, Vote, VocdoniSDKClient } from '../../../src';
+
+const ELECTION_ID = '934234098f1c8d4b7d0c73f2f6b0d2b3a2f7b0e1c2d3e4f5a6b7c8d9e0f1a2b3';
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+
+const CSP_INFO: ICspInfoResponse = {
+  title: 'test',
+  signatureType: ['ecdsa_blind_pidsalted'],
+  authType: 'auth',
+  authSteps: [],
+};
+
+jest.mock('../../../src/util/blind-signing', () => ({
+  getBlindedPayload: jest.fn(() => ({ hexBlinded: 'deadbeef', userSecretData: {} })),
+  CensusBlind: { unblind: jest.fn(() => 'unblinded-signature') },
+}));
+
+jest.mock('../../../src/api/csp', () => ({
+  CspAPI: { sign: jest.fn(() => Promise.resolve({ signature: 'blinded-signature' })) },
+}));
+
+const buildService = () => new CspService({ url: 'https://csp.example', info: CSP_INFO });
+
+describe('Csp service unit tests', () => {
+  describe('CspService.cspVote (static)', () => {
+    it('should forward an explicit weight into the resulting CspVote', () => {
+      const vote = CspService.cspVote(new Vote([1]), 'signature', CspProofType.ECDSA_BLIND_PIDSALTED, 42n);
+      expect(vote.weight).toEqual(42n);
+    });
+    it('should leave the weight undefined when none is given', () => {
+      const vote = CspService.cspVote(new Vote([1]), 'signature', CspProofType.ECDSA_BLIND_PIDSALTED);
+      expect(vote.weight).toBeUndefined();
+    });
+  });
+
+  describe('CspService.cspVote (instance)', () => {
+    it('should forward an explicit weight when cspSign was not called on the instance', () => {
+      const service = buildService();
+      const vote = service.cspVote(new Vote([1]), 'signature', CspProofType.ECDSA_BLIND_PIDSALTED, 7n);
+      expect(vote.weight).toEqual(7n);
+    });
+
+    it('should leave the weight undefined when neither cspSign nor an explicit weight is given', () => {
+      const service = buildService();
+      const vote = service.cspVote(new Vote([1]), 'signature');
+      expect(vote.weight).toBeUndefined();
+    });
+
+    it('should reuse the weight remembered from a preceding cspSign call', async () => {
+      const service = buildService();
+      await service.cspSign(ELECTION_ID, ADDRESS, 'token', 42n);
+      const vote = service.cspVote(new Vote([1]), 'signature');
+      expect(vote.weight).toEqual(42n);
+    });
+
+    it('should accept an explicit weight that matches the one remembered from cspSign', async () => {
+      const service = buildService();
+      await service.cspSign(ELECTION_ID, ADDRESS, 'token', 42n);
+      const vote = service.cspVote(new Vote([1]), 'signature', undefined, 42n);
+      expect(vote.weight).toEqual(42n);
+    });
+
+    it('should throw when the explicit weight conflicts with the one remembered from cspSign', async () => {
+      const service = buildService();
+      await service.cspSign(ELECTION_ID, ADDRESS, 'token', 42n);
+      expect(() => service.cspVote(new Vote([1]), 'signature', undefined, 43n)).toThrow(/42.*43|43.*42/);
+    });
+
+    it('should throw when cspSign signed unweighted but cspVote is given an explicit weight', async () => {
+      const service = buildService();
+      await service.cspSign(ELECTION_ID, ADDRESS, 'token');
+      expect(() => service.cspVote(new Vote([1]), 'signature', undefined, 5n)).toThrow();
+    });
+  });
+
+  describe('VocdoniSDKClient.cspVote', () => {
+    it('should forward the weight to the underlying CspService', () => {
+      const client = new VocdoniSDKClient({ env: EnvOptions.DEV });
+      const vote = client.cspVote(new Vote([1]), 'signature', CspProofType.ECDSA_BLIND_PIDSALTED, 42n);
+      expect(vote.weight).toEqual(42n);
+    });
+
+    it('should leave the weight undefined when none is passed', () => {
+      const client = new VocdoniSDKClient({ env: EnvOptions.DEV });
+      const vote = client.cspVote(new Vote([1]), 'signature');
+      expect(vote.weight).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/types/core/vote.test.ts
+++ b/test/unit/types/core/vote.test.ts
@@ -1,0 +1,62 @@
+import { CAbundle } from '@vocdoni/proto/vochain';
+import { VoteCore } from '../../../../src/core/vote';
+
+const ELECTION_ID = '934234098f1c8d4b7d0c73f2f6b0d2b3a2f7b0e1c2d3e4f5a6b7c8d9e0f1a2b3';
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+
+describe('Vote core tests', () => {
+  describe('encodeVoteWeight', () => {
+    it('should encode the weight as fixed 8-byte big-endian', () => {
+      expect(VoteCore.encodeVoteWeight(1n)).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 1]));
+      expect(VoteCore.encodeVoteWeight(10n)).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 10]));
+      expect(VoteCore.encodeVoteWeight(256n)).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 1, 0]));
+      expect(VoteCore.encodeVoteWeight(0xffffffffffffffffn)).toEqual(
+        new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255])
+      );
+    });
+    it('should throw when the weight does not fit in an unsigned 64 bit integer', () => {
+      expect(() => VoteCore.encodeVoteWeight(0xffffffffffffffffn + 1n)).toThrow(
+        'Vote weight must fit in an unsigned 64 bit integer'
+      );
+      expect(() => VoteCore.encodeVoteWeight(-1n)).toThrow('Vote weight must fit in an unsigned 64 bit integer');
+    });
+    it('should throw when the weight is not a bigint', () => {
+      expect(() => VoteCore.encodeVoteWeight(1.5 as unknown as bigint)).toThrow(
+        'Vote weight must fit in an unsigned 64 bit integer'
+      );
+    });
+  });
+
+  describe('cspCaBundle', () => {
+    it('should build a bundle without weight when none is given', () => {
+      const bundle = VoteCore.cspCaBundle(ELECTION_ID, ADDRESS);
+      expect(Buffer.from(bundle.processId).toString('hex')).toEqual(ELECTION_ID);
+      expect(Buffer.from(bundle.address).toString('hex')).toEqual(ADDRESS.slice(2));
+      expect(bundle.voteWeight).toBeUndefined();
+      const decoded = CAbundle.decode(VoteCore.encodeCspCaBundle(bundle));
+      expect(decoded.voteWeight).toBeUndefined();
+    });
+    it('should include the canonical weight encoding in the bundle', () => {
+      const bundle = VoteCore.cspCaBundle(ELECTION_ID, ADDRESS, 42n);
+      expect(bundle.voteWeight).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 42]));
+    });
+    it('should encode an explicit zero weight as 8 zero bytes rather than omitting it', () => {
+      const bundle = VoteCore.cspCaBundle(ELECTION_ID, ADDRESS, 0n);
+      expect(bundle.voteWeight).toEqual(new Uint8Array(8));
+      const decoded = CAbundle.decode(VoteCore.encodeCspCaBundle(bundle));
+      expect(Buffer.from(decoded.voteWeight).toString('hex')).toEqual('0000000000000000');
+    });
+    it('should round trip through the protobuf encoding', () => {
+      const bundle = VoteCore.cspCaBundle(ELECTION_ID, ADDRESS, 42n);
+      const decoded = CAbundle.decode(VoteCore.encodeCspCaBundle(bundle));
+      expect(Buffer.from(decoded.processId).toString('hex')).toEqual(Buffer.from(bundle.processId).toString('hex'));
+      expect(Buffer.from(decoded.address).toString('hex')).toEqual(Buffer.from(bundle.address).toString('hex'));
+      expect(Buffer.from(decoded.voteWeight).toString('hex')).toEqual('000000000000002a');
+    });
+    it('should encode weighted and unweighted bundles differently', () => {
+      const unweighted = VoteCore.encodeCspCaBundle(VoteCore.cspCaBundle(ELECTION_ID, ADDRESS));
+      const weighted = VoteCore.encodeCspCaBundle(VoteCore.cspCaBundle(ELECTION_ID, ADDRESS, 1n));
+      expect(Buffer.from(weighted).toString('hex')).not.toEqual(Buffer.from(unweighted).toString('hex'));
+    });
+  });
+});

--- a/test/unit/utils/blind-signing.test.ts
+++ b/test/unit/utils/blind-signing.test.ts
@@ -1,0 +1,54 @@
+import { keccak256 } from '@ethersproject/keccak256';
+import { hexlify, hexZeroPad } from '@ethersproject/bytes';
+import { BigInteger, blindSign, newKeyPair, newRequestParameters, pointToHex } from 'blindsecp256k1';
+import { CensusBlind, getBlindedPayload } from '../../../src/util/blind-signing';
+import { VoteCore } from '../../../src/core/vote';
+import { ensure0x, strip0x } from '../../../src/util/common';
+
+const ELECTION_ID = '934234098f1c8d4b7d0c73f2f6b0d2b3a2f7b0e1c2d3e4f5a6b7c8d9e0f1a2b3';
+const ADDRESS = '0x8f6d3b2a1c0e9f8d7c6b5a4938271605f4e3d2c1';
+
+// The message the chain verifies the CSP signature against: keccak256 of the submitted bundle
+const bundleHash = (weight?: bigint): string =>
+  strip0x(keccak256(hexlify(VoteCore.encodeCspCaBundle(VoteCore.cspCaBundle(ELECTION_ID, ADDRESS, weight)))));
+
+// Emulates the CSP side: blind-sign the payload with the given key pair and request parameters
+const cspBlindSign = (sk: BigInteger, k: BigInteger, hexBlinded: string): string =>
+  hexZeroPad(ensure0x(blindSign(sk, BigInteger.fromHex(hexBlinded), k).toString(16)), 32).slice(2);
+
+describe('Blind signing tests', () => {
+  it('should produce an unweighted signature verifiable against the submitted bundle', () => {
+    const { sk, pk } = newKeyPair();
+    const { k, signerR } = newRequestParameters();
+
+    const { hexBlinded, userSecretData } = getBlindedPayload(ELECTION_ID, pointToHex(signerR), ADDRESS);
+    const signature = CensusBlind.unblind(cspBlindSign(sk, k, hexBlinded), userSecretData);
+
+    expect(CensusBlind.verify(bundleHash(), signature, pk)).toBeTruthy();
+  });
+
+  it('should produce a weighted signature verifiable against the submitted weighted bundle', () => {
+    const weight = 42n;
+    const { sk, pk } = newKeyPair();
+    const { k, signerR } = newRequestParameters();
+
+    const { hexBlinded, userSecretData } = getBlindedPayload(ELECTION_ID, pointToHex(signerR), ADDRESS, weight);
+    const signature = CensusBlind.unblind(cspBlindSign(sk, k, hexBlinded), userSecretData);
+
+    // The blinded payload and the submitted bundle are built from the same CAbundle (incl. voteWeight),
+    // so the unblinded signature verifies against the hash of the bundle submitted in the ProofCA
+    expect(CensusBlind.verify(bundleHash(weight), signature, pk)).toBeTruthy();
+    // Regression: it must NOT verify against the weightless bundle the payload was built from before
+    expect(CensusBlind.verify(bundleHash(), signature, pk)).toBeFalsy();
+  });
+
+  it('should not verify a weighted signature against a different weight', () => {
+    const { sk, pk } = newKeyPair();
+    const { k, signerR } = newRequestParameters();
+
+    const { hexBlinded, userSecretData } = getBlindedPayload(ELECTION_ID, pointToHex(signerR), ADDRESS, 42n);
+    const signature = CensusBlind.unblind(cspBlindSign(sk, k, hexBlinded), userSecretData);
+
+    expect(CensusBlind.verify(bundleHash(43n), signature, pk)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This is Opus 5 speaking on behalf of elboletaire.

Client-side counterpart of the CSP salt soft-fork — see #435 and the chain-side vocdoni/vocdoni-node#1424.

## The bug

`getBlindedPayload` built the CA bundle **without** the vote weight, while vote submission built it **with** the weight:

```ts
// src/util/blind-signing.ts (before)
const caBundle = VoteCore.cspCaBundle(electionId, address);          // no weight

// src/core/vote.ts — packageSignedProof
bundle: this.cspCaBundle(electionId, proof.address, proof.weight),   // weight
```

So the CSP blind-signs `keccak256(bundle-without-weight)` while the chain verifies against `keccak256(bundle-with-weight)`. **Every weighted blind vote fails to verify.** Introduced alongside the weight support in #431; unweighted votes were never affected, which is why it went unnoticed.

Verified empirically rather than by inspection — simulating the pre-fix flow, the old signature verifies against the weightless bundle (`true`) and fails against the weighted one (`false`).

## The fix

**1. One bundle, both sides.** `getBlindedPayload` takes an optional `weight` and builds the bundle with it, so the blinded payload and the submitted `ProofCA` bundle come from the same `VoteCore.cspCaBundle(id, addr, weight)` call — identical field ordering and `fromPartial` defaults by construction.

**2. Canonical weight encoding.** `voteWeight` is now fixed 8-byte big-endian (`VoteCore.encodeVoteWeight`) instead of minimal-length hex, matching the `weightBE8` the chain folds into the post-fork salt derivation. Bounds-checked to `[0, 2^64-1]`, and non-`bigint` input is now rejected instead of silently producing a malformed 7-byte buffer (`1.5` → `toString(16)` is `"1.8"` → `Buffer.from("00000000000001.8", "hex")` stops at the dot).

**3. The weight can't silently drift again.** Threading it through two independent optional parameters would mean a caller passing it to `cspSign` but forgetting `cspVote` reproduces the same bug, inverted, with an opaque on-chain rejection. So `CspService` remembers the weight it signed for and `cspVote` reuses it; a conflicting explicit weight throws with both values named rather than silently preferring one.

```ts
const signature = await client.cspSign(signer.address, step1.token, weight);
const vote = client.cspVote(new Vote([0]), signature); // weight reused automatically
```

**4. Explicit `0n` is a weight, not the absence of one.** The old `weight ? … : undefined` guard dropped `0n` as falsy; it now encodes as eight zero bytes. Omitting the weight still produces a byte-identical bundle to before.

## Compatibility

- All new parameters are optional and trailing. Existing 2-arg `cspSign` / 3-arg `cspVote` callers compile and behave identically; the unweighted path is byte-for-byte unchanged.
- No new proof enum or census origin — `ECDSA_PIDSALTED` / `ECDSA_BLIND_PIDSALTED` are reused, as the soft-fork requires.
- **No fork gating needed for this change.** The salt applies to the *key*, not the message, so bundle/weight coherence makes weighted blind votes verify against the current chain too.
- ⚠️ The `voteWeight` encoding change is a wire-format change for anyone on the non-blind `ECDSA_PIDSALTED` path using a signature obtained **outside** this SDK — it must be regenerated against the canonical encoding. The SDK itself only produces blind signatures, which were already broken for weighted votes, so nothing working regresses.

## Deliberately out of scope

Action item 2 of #435 (switching local salted-key reconstruction to `keccak256(ProcessId)[:20]`) is **not** implemented, per the issue's own condition — *"add it if/when the SDK verifies CSP proofs locally"*. Verified rather than assumed: `CensusBlind.verify` has zero call sites in `src/`, `src/util/blind-signing.ts` isn't re-exported from `src/index.ts`, and no salted-key reconstruction exists anywhere in the SDK. Items 1, 3 and 4 are implemented here.

## Tests

`test/unit/utils/blind-signing.test.ts` — full blind flow against an emulated CSP using the real `blindsecp256k1` primitives (`newKeyPair`, `newRequestParameters`, `blindSign` — not mocked). The load-bearing assertion is the regression: a weighted signature verifies against the weighted bundle and **not** against the weightless one the old code built. Confirmed stable over 2000 blind→sign→unblind→verify cycles with random keys, so the short-`k` hazard from vocdoni/saas-backend#617 doesn't apply to this JS path (bigi's `toBuffer(size)` left-pads).

`test/unit/types/core/vote.test.ts` — weight encoding across the uint64 range, overflow / negative / non-bigint rejection, explicit `0n`, protobuf round trip.

`test/unit/services/csp.test.ts` — `cspVote` weight forwarding (static, instance, and via the client), remembered-weight reuse, and both conflict-throw cases.

**75/75 unit tests pass, lint clean.**

## Known gaps

- **No golden vector pinned against the Go encoder.** Every assertion is SDK-internal — the test's `bundleHash()` re-derives the message with the same production encoder — so a *symmetric* error (field order, endianness, `DOMAIN` constant) would pass all tests and still fail on-chain. Worth adding once the vocdoni-node side lands.
- **No weighted end-to-end integration test**, which is literally #435's acceptance criterion. Needs a CSP that attests weights (vocdoni/saas-backend#617). `test/integration/csp.test.ts` still covers the unweighted path unchanged.

Left as `Refs #435` rather than `Closes` — the issue's acceptance depends on the chain and CSP sides, and its rollout is gated to the fork height.
