### PR TITLE
docs: add proportional seat allocation (D'Hondt / Sainte-Laguë) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,16 @@ More information can be found in the [documentation][approval voting documentati
 Here is a [full working example][ranked voting example] of how to create a ranked voting election.
 More information can be found in the [documentation][ranked voting documentation].
 
+#### Proportional seat allocation (D'Hondt / Sainte-Laguë)
+
+Unlike the ranked-ballot examples above, this one needs no custom ballot
+encoding at all - it's an ordinary native single-choice election (each voter
+picks one list/party). The only thing missing from the SDK is the seat
+*allocation* step: turning `fetchResults()`'s vote totals per option into
+integer seat counts. That's pure arithmetic on the aggregate, and needs no
+raw envelope access. Here is a [full working example][party list example]
+of both divisor methods.
+
 ### Other election functionalities
 
 #### Estimate election cost
@@ -1043,6 +1053,7 @@ This SDK is licensed under the [GNU Affero General Public License v3.0][license]
 [approval voting documentation]: https://developer.vocdoni.io/protocol/ballot#multiquestion
 [ranked voting example]: ./examples/typescript/src/ranked.ts
 [ranked voting documentation]: https://developer.vocdoni.io/protocol/ballot#linear-weighted-choice
+[party list example]: ./examples/typescript/src/party-list.ts
 [license]: ./LICENSE
 [devportal]: https://developer.vocdoni.io/sdk
 [builddocs]: ./docs/README.md

--- a/README.md
+++ b/README.md
@@ -335,13 +335,12 @@ More information can be found in the [documentation][ranked voting documentation
 
 #### Proportional seat allocation (D'Hondt / Sainte-Laguë)
 
-Unlike the ranked-ballot examples above, this one needs no custom ballot
-encoding at all - it's an ordinary native single-choice election (each voter
-picks one list/party). The only thing missing from the SDK is the seat
-*allocation* step: turning `fetchResults()`'s vote totals per option into
-integer seat counts. That's pure arithmetic on the aggregate, and needs no
-raw envelope access. Here is a [full working example][party list example]
-of both divisor methods.
+An ordinary native single-choice election (each voter picks one list); the
+only non-native step is turning the aggregate vote totals into seat counts.
+The [full working example][party list example] commits the allocation rule
+(method, seat count, threshold, tie-break) to the election metadata before
+voting opens and reads it back to run the tally, so the result is
+reproducible from the published process.
 
 ### Other election functionalities
 

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -13,7 +13,8 @@
     "start": "ts-node src/index.ts",
     "quadratic": "ts-node src/quadratic.ts",
     "approval": "ts-node src/approval.ts",
-    "ranked": "ts-node src/ranked.ts"
+    "ranked": "ts-node src/ranked.ts",
+    "party-list": "ts-node src/party-list.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/examples/typescript/src/party-list.ts
+++ b/examples/typescript/src/party-list.ts
@@ -23,7 +23,7 @@ import { allocateSeats, AllocationConfig } from './utils/party-list-tally';
 const LISTS = ['List A', 'List B', 'List C'];
 const VOTE_DISTRIBUTION = [11, 7, 4]; // deterministic voters per list, for the demo
 
-const ALLOCATION: AllocationConfig = { method: 'dhondt', seats: 4, threshold: 0 };
+const ALLOCATION: AllocationConfig = { method: 'dhondt', seats: 4, threshold: 0, tieBreak: 'lowerIndex' };
 
 async function main() {
   const totalVoters = VOTE_DISTRIBUTION.reduce((a, b) => a + b, 0);

--- a/examples/typescript/src/party-list.ts
+++ b/examples/typescript/src/party-list.ts
@@ -23,7 +23,12 @@ import { allocateSeats, AllocationConfig } from './utils/party-list-tally';
 const LISTS = ['List A', 'List B', 'List C'];
 const VOTE_DISTRIBUTION = [11, 7, 4]; // deterministic voters per list, for the demo
 
-const ALLOCATION: AllocationConfig = { method: 'dhondt', seats: 4, threshold: 0, tieBreak: 'lowerIndex' };
+const ALLOCATION: AllocationConfig = {
+  method: 'dhondt',
+  seats: 4,
+  threshold: { num: 0, den: 1 }, // no electoral threshold
+  tieBreak: 'lowerIndex',
+};
 
 async function main() {
   const totalVoters = VOTE_DISTRIBUTION.reduce((a, b) => a + b, 0);

--- a/examples/typescript/src/party-list.ts
+++ b/examples/typescript/src/party-list.ts
@@ -1,0 +1,102 @@
+import chalk from 'chalk';
+import { Election, Vote } from '@vocdoni/sdk';
+import { getDefaultClient, waitForElectionReady } from './utils/utils';
+import { getPlainCensus } from './utils/election-process';
+import { allocateSeats } from './utils/party-list-tally';
+
+/**
+ * Example: proportional seat allocation (D'Hondt / Sainte-Laguë) built on
+ * top of the Vocdoni SDK.
+ *
+ * Unlike the ranked-ballot examples in this folder (STV, Condorcet, Borda),
+ * this one needs no custom ballot encoding at all — it's a completely
+ * ordinary native single-choice election (each voter picks one list/party).
+ * The only thing missing from the SDK is the seat *allocation* step: turning
+ * `fetchResults()`'s vote totals per option into integer seat counts. That
+ * step is pure arithmetic on the aggregate — see `utils/party-list-tally.ts`
+ * — and needs no raw envelope access at all.
+ *
+ * Real-world use: D'Hondt is used to elect national/regional legislatures in
+ * dozens of countries (Spain, Portugal, Poland, Israel, Japan, the
+ * Netherlands, Turkey and many more — see
+ * https://en.wikipedia.org/wiki/D%27Hondt_method). Sainte-Laguë (which tends
+ * to produce more proportional results, with less bias towards larger
+ * parties) is used by Germany, New Zealand, Sweden and Norway — see
+ * https://en.wikipedia.org/wiki/Sainte-Lagu%C3%AB_method and
+ * https://electoral-reform.org.uk/what-is-the-difference-between-dhondt-sainte-lague-and-hare/
+ * for a comparison of the two.
+ *
+ * https://developer.vocdoni.io/protocol/ballot
+ */
+
+const SEATS = 4;
+const LISTS = ['List A', 'List B', 'List C'];
+
+// how many of the (deterministic, for this demo) voters choose each list
+const VOTE_DISTRIBUTION = [11, 7, 4]; // 11 for List A, 7 for List B, 4 for List C
+
+async function main() {
+  // Reference case, hand-verified: votes [550, 350, 200], 4 seats.
+  // D'Hondt quotients (divide by 1,2,3,4...): A 550/275/183.3/137.5,
+  // B 350/175/116.7/87.5, C 200/100/66.7/50. Top 4: 550(A), 350(B), 275(A),
+  // 200(C) -> seats [2, 1, 1].
+  const reference = allocateSeats([550, 350, 200], 4, 'dhondt');
+  if (reference.join(',') !== '2,1,1') {
+    throw new Error(`D'Hondt reference case failed: expected [2,1,1], got ${reference}`);
+  }
+
+  const totalVoters = VOTE_DISTRIBUTION.reduce((a, b) => a + b, 0);
+  console.log('Creating census with some random wallets...');
+  const { census, participants } = getPlainCensus(totalVoters);
+
+  console.log('Creating election...');
+  const { client } = getDefaultClient();
+  await client.createAccount();
+
+  const endDate = new Date();
+  endDate.setHours(endDate.getHours() + 10);
+  const election = Election.from({
+    title: 'Party list vote — council seats ' + new Date().toISOString(),
+    description: 'Pick one list.',
+    endDate: endDate.getTime(),
+    census,
+  });
+  election.addQuestion(
+    'Which list do you support?',
+    '',
+    LISTS.map((title, value) => ({ title, value }))
+  );
+
+  const electionId = await client.createElection(election);
+  client.setElectionId(electionId);
+  console.log(chalk.green('Election created!'), chalk.blue(electionId));
+  await waitForElectionReady(client, electionId);
+
+  console.log('Submitting votes...');
+  let voterIndex = 0;
+  for (let list = 0; list < VOTE_DISTRIBUTION.length; list++) {
+    for (let i = 0; i < VOTE_DISTRIBUTION[list]; i++) {
+      const participant = participants[voterIndex++];
+      const voterClient = getDefaultClient(participant).client;
+      voterClient.setElectionId(electionId);
+      await voterClient.submitVote(new Vote([list]));
+    }
+  }
+
+  const finalElection = await client.fetchElection(electionId);
+  const voteCounts = finalElection.results[0].map((count) => Number(count));
+  const seats = allocateSeats(voteCounts, SEATS, 'dhondt');
+
+  console.log(chalk.green('Votes per list:'), JSON.stringify(voteCounts));
+  console.log(chalk.green('Seats per list (D\'Hondt):'), LISTS.map((l, i) => `${l}: ${seats[i]}`).join(', '));
+}
+
+main()
+  .then(() => {
+    console.log(chalk.green('Done ✅'));
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/examples/typescript/src/party-list.ts
+++ b/examples/typescript/src/party-list.ts
@@ -2,49 +2,30 @@ import chalk from 'chalk';
 import { Election, Vote } from '@vocdoni/sdk';
 import { getDefaultClient, waitForElectionReady } from './utils/utils';
 import { getPlainCensus } from './utils/election-process';
-import { allocateSeats } from './utils/party-list-tally';
+import { allocateSeats, AllocationConfig } from './utils/party-list-tally';
 
 /**
- * Example: proportional seat allocation (D'Hondt / Sainte-Laguë) built on
- * top of the Vocdoni SDK.
+ * Example: proportional seat allocation (D'Hondt / Sainte-Laguë).
  *
- * Unlike the ranked-ballot examples in this folder (STV, Condorcet, Borda),
- * this one needs no custom ballot encoding at all — it's a completely
- * ordinary native single-choice election (each voter picks one list/party).
- * The only thing missing from the SDK is the seat *allocation* step: turning
- * `fetchResults()`'s vote totals per option into integer seat counts. That
- * step is pure arithmetic on the aggregate — see `utils/party-list-tally.ts`
- * — and needs no raw envelope access at all.
+ * Ballot: a native single-choice election — each voter picks one list.
+ * Result: `fetchElection().results[0]` is the vote total per list.
  *
- * Real-world use: D'Hondt is used to elect national/regional legislatures in
- * dozens of countries (Spain, Portugal, Poland, Israel, Japan, the
- * Netherlands, Turkey and many more — see
- * https://en.wikipedia.org/wiki/D%27Hondt_method). Sainte-Laguë (which tends
- * to produce more proportional results, with less bias towards larger
- * parties) is used by Germany, New Zealand, Sweden and Norway — see
- * https://en.wikipedia.org/wiki/Sainte-Lagu%C3%AB_method and
- * https://electoral-reform.org.uk/what-is-the-difference-between-dhondt-sainte-lague-and-hare/
- * for a comparison of the two.
+ * The only non-native step is turning those totals into seats. The rule for
+ * doing so (method, seat count, threshold, tie-break) is committed to the
+ * election metadata before voting opens, so an observer can reproduce the
+ * allocation and the organizer cannot change it after seeing the votes. The
+ * tally below reads the rule back from the published metadata, not from a
+ * local constant.
  *
  * https://developer.vocdoni.io/protocol/ballot
  */
 
-const SEATS = 4;
 const LISTS = ['List A', 'List B', 'List C'];
+const VOTE_DISTRIBUTION = [11, 7, 4]; // deterministic voters per list, for the demo
 
-// how many of the (deterministic, for this demo) voters choose each list
-const VOTE_DISTRIBUTION = [11, 7, 4]; // 11 for List A, 7 for List B, 4 for List C
+const ALLOCATION: AllocationConfig = { method: 'dhondt', seats: 4, threshold: 0 };
 
 async function main() {
-  // Reference case, hand-verified: votes [550, 350, 200], 4 seats.
-  // D'Hondt quotients (divide by 1,2,3,4...): A 550/275/183.3/137.5,
-  // B 350/175/116.7/87.5, C 200/100/66.7/50. Top 4: 550(A), 350(B), 275(A),
-  // 200(C) -> seats [2, 1, 1].
-  const reference = allocateSeats([550, 350, 200], 4, 'dhondt');
-  if (reference.join(',') !== '2,1,1') {
-    throw new Error(`D'Hondt reference case failed: expected [2,1,1], got ${reference}`);
-  }
-
   const totalVoters = VOTE_DISTRIBUTION.reduce((a, b) => a + b, 0);
   console.log('Creating census with some random wallets...');
   const { census, participants } = getPlainCensus(totalVoters);
@@ -61,6 +42,8 @@ async function main() {
     endDate: endDate.getTime(),
     census,
   });
+  // Commit the allocation rule on-chain, before any vote is cast.
+  election.meta = { allocation: ALLOCATION };
   election.addQuestion(
     'Which list do you support?',
     '',
@@ -76,19 +59,19 @@ async function main() {
   let voterIndex = 0;
   for (let list = 0; list < VOTE_DISTRIBUTION.length; list++) {
     for (let i = 0; i < VOTE_DISTRIBUTION[list]; i++) {
-      const participant = participants[voterIndex++];
-      const voterClient = getDefaultClient(participant).client;
+      const voterClient = getDefaultClient(participants[voterIndex++]).client;
       voterClient.setElectionId(electionId);
       await voterClient.submitVote(new Vote([list]));
     }
   }
 
   const finalElection = await client.fetchElection(electionId);
-  const voteCounts = finalElection.results[0].map((count) => Number(count));
-  const seats = allocateSeats(voteCounts, SEATS, 'dhondt');
+  const votes = finalElection.results[0].map((count) => BigInt(count));
+  const { allocation } = finalElection.meta as { allocation: AllocationConfig };
+  const seats = allocateSeats(votes, allocation);
 
-  console.log(chalk.green('Votes per list:'), JSON.stringify(voteCounts));
-  console.log(chalk.green('Seats per list (D\'Hondt):'), LISTS.map((l, i) => `${l}: ${seats[i]}`).join(', '));
+  console.log(chalk.green('Votes per list:'), votes.map(String).join(', '));
+  console.log(chalk.green(`Seats per list (${allocation.method}):`), LISTS.map((l, i) => `${l}: ${seats[i]}`).join(', '));
 }
 
 main()

--- a/examples/typescript/src/utils/party-list-tally.ts
+++ b/examples/typescript/src/utils/party-list-tally.ts
@@ -1,0 +1,33 @@
+/**
+ * Proportional seat allocation (D'Hondt / Sainte-Laguë highest-averages
+ * methods) — not a native Vocdoni election type as a *seat allocation* (see
+ * party-list.ts for why), computed here from the native aggregate vote
+ * totals per option.
+ *
+ * Unlike the other examples in this folder, this one needs no custom ballot
+ * encoding or off-chain per-voter tally at all: each voter casts one native
+ * single-choice vote for their preferred list, `fetchResults()` already
+ * gives the correct aggregate vote total per list, and only the seat
+ * *allocation* step (turning vote totals into integer seat counts) is
+ * missing from the SDK.
+ */
+
+export type DivisorMethod = 'dhondt' | 'sainte-lague';
+
+export function allocateSeats(votes: number[], seats: number, method: DivisorMethod): number[] {
+  const result = new Array(votes.length).fill(0);
+  for (let s = 0; s < seats; s++) {
+    let best = -1;
+    let bestQuotient = -1;
+    for (let i = 0; i < votes.length; i++) {
+      const divisor = method === 'dhondt' ? result[i] + 1 : 2 * result[i] + 1;
+      const quotient = votes[i] / divisor;
+      if (quotient > bestQuotient) {
+        bestQuotient = quotient;
+        best = i;
+      }
+    }
+    result[best]++;
+  }
+  return result;
+}

--- a/examples/typescript/src/utils/party-list-tally.ts
+++ b/examples/typescript/src/utils/party-list-tally.ts
@@ -19,24 +19,30 @@ export type DivisorMethod = 'dhondt' | 'sainte-lague';
 export interface AllocationConfig {
   method: DivisorMethod;
   seats: number;
-  /** Minimum share of the total vote to receive any seat. 0 disables it. */
-  threshold?: number;
+  /**
+   * Minimum share of the total vote to receive any seat, as an exact
+   * fraction: `{ num: 5, den: 100 }` is 5%. Omitted disables it. A fraction
+   * (not a float) so thresholds that are not representable in binary — 1/3,
+   * 2/3 — are compared exactly.
+   */
+  threshold?: { num: number; den: number };
   /** How ties in the seat-by-seat comparison are broken. */
-  tieBreak?: 'lowerIndex';
+  tieBreak: 'lowerIndex';
 }
 
 const divisor = (method: DivisorMethod, seatsWon: number): bigint =>
   method === 'dhondt' ? BigInt(seatsWon + 1) : BigInt(2 * seatsWon + 1);
 
 export function allocateSeats(votes: bigint[], config: AllocationConfig): number[] {
-  const { method, seats, threshold = 0 } = config;
+  const { method, seats, threshold = { num: 0, den: 1 } } = config;
 
   const total = votes.reduce((a, b) => a + b, 0n);
-  // v / total >= threshold  <=>  v * SCALE >= round(threshold * SCALE) * total
-  // compared directly (no intermediate floored cutoff) so a list exactly at
-  // the boundary from below is never let in by a rounding-down cutoff.
-  const thresholdScaled = BigInt(Math.round(threshold * 1_000_000));
-  const eligible = votes.map((v) => (v * 1_000_000n >= thresholdScaled * total && v > 0n ? v : 0n));
+  // v / total >= num / den  <=>  v * den >= num * total, cross-multiplied in
+  // bigint: no intermediate cutoff to floor, and no float to round, so a list
+  // exactly on the boundary is neither let in nor kept out by rounding.
+  const num = BigInt(threshold.num);
+  const den = BigInt(threshold.den);
+  const eligible = votes.map((v) => (v * den >= num * total && v > 0n ? v : 0n));
 
   const result: number[] = new Array(votes.length).fill(0);
   for (let s = 0; s < seats; s++) {

--- a/examples/typescript/src/utils/party-list-tally.ts
+++ b/examples/typescript/src/utils/party-list-tally.ts
@@ -1,32 +1,54 @@
 /**
- * Proportional seat allocation (D'Hondt / Sainte-Laguë highest-averages
- * methods) — not a native Vocdoni election type as a *seat allocation* (see
- * party-list.ts for why), computed here from the native aggregate vote
- * totals per option.
+ * Highest-averages seat allocation (D'Hondt / Sainte-Laguë) from the native
+ * per-list vote totals.
  *
- * Unlike the other examples in this folder, this one needs no custom ballot
- * encoding or off-chain per-voter tally at all: each voter casts one native
- * single-choice vote for their preferred list, `fetchResults()` already
- * gives the correct aggregate vote total per list, and only the seat
- * *allocation* step (turning vote totals into integer seat counts) is
- * missing from the SDK.
+ * The vote is an ordinary native single-choice election; the only step the
+ * SDK does not do is turning `results[0]` (vote total per list) into seat
+ * counts. That step is defined entirely by `AllocationConfig`, which the
+ * example commits to the election metadata so the result is reproducible
+ * and fixed before any vote is cast.
+ *
+ * Votes are kept as bigint and quotients are compared by cross-multiplication,
+ * so there is no floating-point rounding. Ties go to the lower list index.
+ * These are the bare divisor methods: real jurisdictions layer extra rules
+ * (levelling seats, apparentement, regional sub-allocation) on top.
  */
 
 export type DivisorMethod = 'dhondt' | 'sainte-lague';
 
-export function allocateSeats(votes: number[], seats: number, method: DivisorMethod): number[] {
-  const result = new Array(votes.length).fill(0);
+export interface AllocationConfig {
+  method: DivisorMethod;
+  seats: number;
+  /** Minimum share of the total vote to receive any seat. 0 disables it. */
+  threshold?: number;
+}
+
+const divisor = (method: DivisorMethod, seatsWon: number): bigint =>
+  method === 'dhondt' ? BigInt(seatsWon + 1) : BigInt(2 * seatsWon + 1);
+
+export function allocateSeats(votes: bigint[], config: AllocationConfig): number[] {
+  const { method, seats, threshold = 0 } = config;
+
+  const total = votes.reduce((a, b) => a + b, 0n);
+  // integer cutoff: floor(threshold * total), threshold scaled to avoid floats
+  const cutoff = (BigInt(Math.round(threshold * 1_000_000)) * total) / 1_000_000n;
+  const eligible = votes.map((v) => (v >= cutoff && v > 0n ? v : 0n));
+
+  const result: number[] = new Array(votes.length).fill(0);
   for (let s = 0; s < seats; s++) {
     let best = -1;
-    let bestQuotient = -1;
     for (let i = 0; i < votes.length; i++) {
-      const divisor = method === 'dhondt' ? result[i] + 1 : 2 * result[i] + 1;
-      const quotient = votes[i] / divisor;
-      if (quotient > bestQuotient) {
-        bestQuotient = quotient;
+      if (eligible[i] === 0n) continue;
+      if (best === -1) {
+        best = i;
+        continue;
+      }
+      // eligible[i] / divisor(result[i])  >  eligible[best] / divisor(result[best])
+      if (eligible[i] * divisor(method, result[best]) > eligible[best] * divisor(method, result[i])) {
         best = i;
       }
     }
+    if (best === -1) break; // every list below threshold or with no votes
     result[best]++;
   }
   return result;

--- a/examples/typescript/src/utils/party-list-tally.ts
+++ b/examples/typescript/src/utils/party-list-tally.ts
@@ -21,6 +21,8 @@ export interface AllocationConfig {
   seats: number;
   /** Minimum share of the total vote to receive any seat. 0 disables it. */
   threshold?: number;
+  /** How ties in the seat-by-seat comparison are broken. */
+  tieBreak?: 'lowerIndex';
 }
 
 const divisor = (method: DivisorMethod, seatsWon: number): bigint =>
@@ -30,9 +32,11 @@ export function allocateSeats(votes: bigint[], config: AllocationConfig): number
   const { method, seats, threshold = 0 } = config;
 
   const total = votes.reduce((a, b) => a + b, 0n);
-  // integer cutoff: floor(threshold * total), threshold scaled to avoid floats
-  const cutoff = (BigInt(Math.round(threshold * 1_000_000)) * total) / 1_000_000n;
-  const eligible = votes.map((v) => (v >= cutoff && v > 0n ? v : 0n));
+  // v / total >= threshold  <=>  v * SCALE >= round(threshold * SCALE) * total
+  // compared directly (no intermediate floored cutoff) so a list exactly at
+  // the boundary from below is never let in by a rounding-down cutoff.
+  const thresholdScaled = BigInt(Math.round(threshold * 1_000_000));
+  const eligible = votes.map((v) => (v * 1_000_000n >= thresholdScaled * total && v > 0n ? v : 0n));
 
   const result: number[] = new Array(votes.length).fill(0);
   for (let s = 0; s < seats; s++) {

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. BigInt literals (0n) require es2020+. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */

--- a/test/unit/party-list-tally.test.ts
+++ b/test/unit/party-list-tally.test.ts
@@ -26,6 +26,11 @@ describe('Highest-averages seat allocation', () => {
     expect(allocateSeats(v(10, 10), { method: 'dhondt', seats: 3, threshold: 0.9 })).toEqual([0, 0]);
   });
 
+  it('excludes a list that falls just short of the threshold, no rounding-down leak', () => {
+    // total 9, 50% threshold: 4/9 = 44.4% must NOT clear it (floor(0.5*9)=4 would wrongly let it in)
+    expect(allocateSeats(v(5, 4), { method: 'dhondt', seats: 4, threshold: 0.5 })).toEqual([4, 0]);
+  });
+
   it('handles vote totals past Number.MAX_SAFE_INTEGER without rounding', () => {
     const big = v(9007199254740993, 9007199254740991); // differ by 2, both > 2^53
     expect(allocateSeats(big, { method: 'dhondt', seats: 2 })).toEqual([1, 1]);

--- a/test/unit/party-list-tally.test.ts
+++ b/test/unit/party-list-tally.test.ts
@@ -1,0 +1,34 @@
+import { allocateSeats } from '../../examples/typescript/src/utils/party-list-tally';
+
+const v = (...n: number[]): bigint[] => n.map(BigInt);
+
+describe('Highest-averages seat allocation', () => {
+  it("D'Hondt reference case: [550, 350, 200] over 4 seats -> [2, 1, 1]", () => {
+    expect(allocateSeats(v(550, 350, 200), { method: 'dhondt', seats: 4 })).toEqual([2, 1, 1]);
+  });
+
+  it("Sainte-Laguë diverges from D'Hondt: [100, 80, 30, 20] over 8 seats", () => {
+    expect(allocateSeats(v(100, 80, 30, 20), { method: 'dhondt', seats: 8 })).toEqual([4, 3, 1, 0]);
+    expect(allocateSeats(v(100, 80, 30, 20), { method: 'sainte-lague', seats: 8 })).toEqual([3, 3, 1, 1]);
+  });
+
+  it('applies an eligibility threshold before allocating', () => {
+    // total 1000, 5% cutoff = 50; lists C (40) and D (20) get no seats
+    expect(allocateSeats(v(600, 340, 40, 20), { method: 'dhondt', seats: 4, threshold: 0.05 })).toEqual([3, 1, 0, 0]);
+  });
+
+  it('breaks quotient ties by lower list index', () => {
+    // equal votes: every seat goes to the lower index first
+    expect(allocateSeats(v(100, 100), { method: 'dhondt', seats: 3 })).toEqual([2, 1]);
+  });
+
+  it('returns all zeros when no list clears the threshold', () => {
+    expect(allocateSeats(v(10, 10), { method: 'dhondt', seats: 3, threshold: 0.9 })).toEqual([0, 0]);
+  });
+
+  it('handles vote totals past Number.MAX_SAFE_INTEGER without rounding', () => {
+    const big = v(9007199254740993, 9007199254740991); // differ by 2, both > 2^53
+    expect(allocateSeats(big, { method: 'dhondt', seats: 2 })).toEqual([1, 1]);
+    expect(allocateSeats(big, { method: 'dhondt', seats: 1 })).toEqual([1, 0]);
+  });
+});

--- a/test/unit/party-list-tally.test.ts
+++ b/test/unit/party-list-tally.test.ts
@@ -1,39 +1,50 @@
 import { allocateSeats } from '../../examples/typescript/src/utils/party-list-tally';
 
 const v = (...n: number[]): bigint[] => n.map(BigInt);
+const TIE_BREAK = { tieBreak: 'lowerIndex' } as const;
 
 describe('Highest-averages seat allocation', () => {
   it("D'Hondt reference case: [550, 350, 200] over 4 seats -> [2, 1, 1]", () => {
-    expect(allocateSeats(v(550, 350, 200), { method: 'dhondt', seats: 4 })).toEqual([2, 1, 1]);
+    expect(allocateSeats(v(550, 350, 200), { method: 'dhondt', seats: 4, ...TIE_BREAK })).toEqual([2, 1, 1]);
   });
 
   it("Sainte-Laguë diverges from D'Hondt: [100, 80, 30, 20] over 8 seats", () => {
-    expect(allocateSeats(v(100, 80, 30, 20), { method: 'dhondt', seats: 8 })).toEqual([4, 3, 1, 0]);
-    expect(allocateSeats(v(100, 80, 30, 20), { method: 'sainte-lague', seats: 8 })).toEqual([3, 3, 1, 1]);
+    expect(allocateSeats(v(100, 80, 30, 20), { method: 'dhondt', seats: 8, ...TIE_BREAK })).toEqual([4, 3, 1, 0]);
+    expect(allocateSeats(v(100, 80, 30, 20), { method: 'sainte-lague', seats: 8, ...TIE_BREAK })).toEqual([3, 3, 1, 1]);
   });
 
   it('applies an eligibility threshold before allocating', () => {
     // total 1000, 5% cutoff = 50; lists C (40) and D (20) get no seats
-    expect(allocateSeats(v(600, 340, 40, 20), { method: 'dhondt', seats: 4, threshold: 0.05 })).toEqual([3, 1, 0, 0]);
+    const config = { method: 'dhondt' as const, seats: 4, threshold: { num: 5, den: 100 }, ...TIE_BREAK };
+    expect(allocateSeats(v(600, 340, 40, 20), config)).toEqual([3, 1, 0, 0]);
   });
 
   it('breaks quotient ties by lower list index', () => {
     // equal votes: every seat goes to the lower index first
-    expect(allocateSeats(v(100, 100), { method: 'dhondt', seats: 3 })).toEqual([2, 1]);
+    expect(allocateSeats(v(100, 100), { method: 'dhondt', seats: 3, ...TIE_BREAK })).toEqual([2, 1]);
   });
 
   it('returns all zeros when no list clears the threshold', () => {
-    expect(allocateSeats(v(10, 10), { method: 'dhondt', seats: 3, threshold: 0.9 })).toEqual([0, 0]);
+    const config = { method: 'dhondt' as const, seats: 3, threshold: { num: 9, den: 10 }, ...TIE_BREAK };
+    expect(allocateSeats(v(10, 10), config)).toEqual([0, 0]);
   });
 
   it('excludes a list that falls just short of the threshold, no rounding-down leak', () => {
     // total 9, 50% threshold: 4/9 = 44.4% must NOT clear it (floor(0.5*9)=4 would wrongly let it in)
-    expect(allocateSeats(v(5, 4), { method: 'dhondt', seats: 4, threshold: 0.5 })).toEqual([4, 0]);
+    const config = { method: 'dhondt' as const, seats: 4, threshold: { num: 1, den: 2 }, ...TIE_BREAK };
+    expect(allocateSeats(v(5, 4), config)).toEqual([4, 0]);
+  });
+
+  it('admits a list exactly on a non-binary threshold: 2/3 of the vote clears 2/3', () => {
+    // Scaling the threshold to an integer (round(2/3 * 1e6) = 666667 > 2/3)
+    // would wrongly exclude a list holding exactly the required share.
+    const config = { method: 'dhondt' as const, seats: 2, threshold: { num: 2, den: 3 }, ...TIE_BREAK };
+    expect(allocateSeats(v(2, 1), config)).toEqual([2, 0]);
   });
 
   it('handles vote totals past Number.MAX_SAFE_INTEGER without rounding', () => {
     const big = v(9007199254740993, 9007199254740991); // differ by 2, both > 2^53
-    expect(allocateSeats(big, { method: 'dhondt', seats: 2 })).toEqual([1, 1]);
-    expect(allocateSeats(big, { method: 'dhondt', seats: 1 })).toEqual([1, 0]);
+    expect(allocateSeats(big, { method: 'dhondt', seats: 2, ...TIE_BREAK })).toEqual([1, 1]);
+    expect(allocateSeats(big, { method: 'dhondt', seats: 1, ...TIE_BREAK })).toEqual([1, 0]);
   });
 });


### PR DESCRIPTION
## Summary

Suggestion / reference example, not a request to change core SDK behaviour.

Unlike the ranked-ballot examples in this PR series (#438-#441), this one needs no custom ballot encoding at all — it's an ordinary native single-choice election (each voter picks one list/party). The only thing missing from the SDK is the seat *allocation* step: turning `fetchResults()`'s vote totals per option into integer seat counts, which is pure arithmetic on the aggregate and needs no raw envelope access at all. No `@vocdoni/sdk` version bump needed for this one — it builds fine against what's currently pinned.

## Real-world use

D'Hondt elects national/regional legislatures in dozens of countries (Spain, Portugal, Poland, Israel, Japan, the Netherlands, Turkey and many more).
https://en.wikipedia.org/wiki/D%27Hondt_method

Sainte-Laguë (generally more proportional, less bias towards larger parties) is used by Germany, New Zealand, Sweden and Norway.
https://en.wikipedia.org/wiki/Sainte-Lagu%C3%AB_method

## Testing

The allocation function is hand-verified against a worked example (votes [550, 350, 200], 4 seats → seats [2, 1, 1] for both methods on this particular input). Network flow follows the pattern of the existing examples; not run fully end-to-end from my environment (STG faucet unreachable at the time of writing) but this one at least confirms the type surface and native `Election`/`Vote` flow work unmodified against the currently-pinned SDK version.