### PR TITLE
docs: add two-round (runoff) election example

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,15 @@ More information can be found in the [documentation][approval voting documentati
 Here is a [full working example][ranked voting example] of how to create a ranked voting election.
 More information can be found in the [documentation][ranked voting documentation].
 
+#### Two-round (runoff) elections
+
+Not a native election type — there's no single-election primitive for "if
+nobody clears 50%, automatically hold a second round between the top two".
+This example shows the orchestration: two ordinary native single-choice
+elections, chained programmatically. Nothing here needs a custom tally -
+`fetchResults()` is enough for both rounds. Here is a
+[full working example][runoff example].
+
 ### Other election functionalities
 
 #### Estimate election cost
@@ -1043,6 +1052,7 @@ This SDK is licensed under the [GNU Affero General Public License v3.0][license]
 [approval voting documentation]: https://developer.vocdoni.io/protocol/ballot#multiquestion
 [ranked voting example]: ./examples/typescript/src/ranked.ts
 [ranked voting documentation]: https://developer.vocdoni.io/protocol/ballot#linear-weighted-choice
+[runoff example]: ./examples/typescript/src/runoff.ts
 [license]: ./LICENSE
 [devportal]: https://developer.vocdoni.io/sdk
 [builddocs]: ./docs/README.md

--- a/README.md
+++ b/README.md
@@ -335,12 +335,12 @@ More information can be found in the [documentation][ranked voting documentation
 
 #### Two-round (runoff) elections
 
-Not a native election type — there's no single-election primitive for "if
-nobody clears 50%, automatically hold a second round between the top two".
-This example shows the orchestration: two ordinary native single-choice
-elections, chained programmatically. Nothing here needs a custom tally -
-`fetchResults()` is enough for both rounds. Here is a
-[full working example][runoff example].
+Orchestration of two ordinary native single-choice elections by one
+organiser over one census. The [full working example][runoff example] ends
+round 1 before reading its result, commits the runoff rule (majority
+denominator, tie-break) to round 1's metadata and links round 2 back to it.
+A round-2 vote is a fresh vote by the same electorate, not a transfer of
+round-1 votes.
 
 ### Other election functionalities
 

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -13,7 +13,8 @@
     "start": "ts-node src/index.ts",
     "quadratic": "ts-node src/quadratic.ts",
     "approval": "ts-node src/approval.ts",
-    "ranked": "ts-node src/ranked.ts"
+    "ranked": "ts-node src/ranked.ts",
+    "runoff": "ts-node src/runoff.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/examples/typescript/src/runoff.ts
+++ b/examples/typescript/src/runoff.ts
@@ -1,0 +1,118 @@
+import chalk from 'chalk';
+import { Election, Vote } from '@vocdoni/sdk';
+import { getDefaultClient, waitForElectionReady } from './utils/utils';
+import { getPlainCensus } from './utils/election-process';
+
+/**
+ * Example: two-round (runoff) elections built on top of the Vocdoni SDK.
+ *
+ * Not a native election type — there's no single-election primitive for "if
+ * nobody clears 50%, automatically hold a second round between the top two".
+ * This example shows the orchestration: two ordinary native single-choice
+ * elections, chained programmatically. Nothing here needs a custom tally —
+ * `fetchResults()` is enough for both rounds — the missing piece is just the
+ * decision logic and the second `createElection()` call.
+ *
+ * Real-world use: the two-round system is the most common single-winner
+ * system worldwide for presidential elections — used by France (president,
+ * legislature and regional elections), and at least 40 countries overall,
+ * concentrated in Europe, Africa and South America. See
+ * https://en.wikipedia.org/wiki/Two-round_system and
+ * https://www.france24.com/en/france/20220211-explainer-how-does-france-s-two-round-presidential-election-work
+ *
+ * https://developer.vocdoni.io/protocol/ballot
+ */
+
+const CANDIDATES = ['Alameda', 'Bettencourt', 'Carvalho', 'Dias'];
+
+// deterministic distribution for this demo — nobody clears 50%, so a second
+// round between the top two (Alameda, Bettencourt) is expected
+const FIRST_ROUND_DISTRIBUTION = [5, 4, 2, 1]; // votes per candidate, in CANDIDATES order
+
+async function runSingleChoiceElection(title: string, options: string[], distribution: number[]) {
+  const totalVoters = distribution.reduce((a, b) => a + b, 0);
+  const { census, participants } = getPlainCensus(totalVoters);
+
+  const { client } = getDefaultClient();
+  await client.createAccount();
+
+  const endDate = new Date();
+  endDate.setHours(endDate.getHours() + 10);
+  const election = Election.from({ title, description: '', endDate: endDate.getTime(), census });
+  election.addQuestion(
+    title,
+    '',
+    options.map((option, value) => ({ title: option, value }))
+  );
+
+  const electionId = await client.createElection(election);
+  client.setElectionId(electionId);
+  console.log(chalk.green('Election created!'), chalk.blue(electionId));
+  await waitForElectionReady(client, electionId);
+
+  let voterIndex = 0;
+  for (let choice = 0; choice < distribution.length; choice++) {
+    for (let i = 0; i < distribution[choice]; i++) {
+      const voterClient = getDefaultClient(participants[voterIndex++]).client;
+      voterClient.setElectionId(electionId);
+      await voterClient.submitVote(new Vote([choice]));
+    }
+  }
+
+  const finalElection = await client.fetchElection(electionId);
+  const voteCounts = finalElection.results[0].map((count) => Number(count));
+  const total = voteCounts.reduce((a, b) => a + b, 0);
+  return { electionId, voteCounts, total };
+}
+
+async function main() {
+  console.log(chalk.yellow('Round 1'));
+  const round1 = await runSingleChoiceElection(
+    'Council presidency, round 1 ' + new Date().toISOString(),
+    CANDIDATES,
+    FIRST_ROUND_DISTRIBUTION
+  );
+  console.log('Votes:', CANDIDATES.map((c, i) => `${c}: ${round1.voteCounts[i]}`).join(', '));
+
+  const leaderIndex = round1.voteCounts.reduce((best, v, i) => (v > round1.voteCounts[best] ? i : best), 0);
+  const leaderShare = round1.voteCounts[leaderIndex] / round1.total;
+
+  if (leaderShare > 0.5) {
+    console.log(chalk.green(`${CANDIDATES[leaderIndex]} wins in round 1 with ${(leaderShare * 100).toFixed(1)}%`));
+    return;
+  }
+
+  console.log(
+    chalk.yellow(`No absolute majority (leader ${CANDIDATES[leaderIndex]} at ${(leaderShare * 100).toFixed(1)}%) — running round 2`)
+  );
+
+  const ranked = round1.voteCounts
+    .map((votes, index) => ({ index, votes }))
+    .sort((a, b) => b.votes - a.votes);
+  const [first, second] = ranked;
+  const runoffCandidates = [CANDIDATES[first.index], CANDIDATES[second.index]];
+
+  console.log(chalk.yellow('Round 2:'), runoffCandidates.join(' vs '));
+  // second-round distribution derived from a plausible transfer of the
+  // eliminated candidates' votes — hardcoded here for a reproducible demo
+  const round2 = await runSingleChoiceElection(
+    'Council presidency, round 2 ' + new Date().toISOString(),
+    runoffCandidates,
+    [7, 5]
+  );
+  const winnerIndex = round2.voteCounts[0] > round2.voteCounts[1] ? 0 : 1;
+  console.log(
+    chalk.green(`Winner: ${runoffCandidates[winnerIndex]}`),
+    `(${round2.voteCounts[0]} vs ${round2.voteCounts[1]})`
+  );
+}
+
+main()
+  .then(() => {
+    console.log(chalk.green('Done ✅'));
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/examples/typescript/src/runoff.ts
+++ b/examples/typescript/src/runoff.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { CustomMeta, Election, PlainCensus, Vote, VocdoniSDKClient } from '@vocdoni/sdk';
+import { ElectionMeta, Election, PlainCensus, Vote, VocdoniSDKClient } from '@vocdoni/sdk';
 import { Wallet } from '@ethersproject/wallet';
 import { getDefaultClient, waitForElectionReady } from './utils/utils';
 import { getPlainCensus } from './utils/election-process';
@@ -20,7 +20,11 @@ import { needsRunoff, roundWinner, runoffContenders, RunoffRules } from './utils
  */
 
 const CANDIDATES = ['Alameda', 'Bettencourt', 'Carvalho', 'Dias'];
-const RULES: RunoffRules = { majorityThreshold: 0.5 };
+const RULES: RunoffRules = {
+  majorityThreshold: { num: 1, den: 2 },
+  denominator: 'validVotes',
+  tieBreak: 'lowerIndex',
+};
 
 // Deterministic demo. Round 1: nobody clears 50%. Round 2: the same voters
 // choose between the top two.
@@ -34,8 +38,8 @@ async function runRound(
   title: string,
   options: string[],
   distribution: number[],
-  meta: CustomMeta
-): Promise<{ electionId: string; votes: bigint[] }> {
+  meta: ElectionMeta
+): Promise<{ electionId: string; votes: bigint[]; meta: ElectionMeta }> {
   const endDate = new Date();
   endDate.setHours(endDate.getHours() + 10);
   const election = Election.from({ title, description: '', endDate: endDate.getTime(), census });
@@ -63,7 +67,18 @@ async function runRound(
   // End the round before reading its results — no decision on provisional counts.
   await client.endElection(electionId);
   const finalElection = await client.fetchElection(electionId);
-  return { electionId, votes: finalElection.results[0].map((count) => BigInt(count)) };
+  return {
+    electionId,
+    votes: finalElection.results[0].map((count) => BigInt(count)),
+    meta: finalElection.meta,
+  };
+}
+
+/** A round with no valid votes has no winner — never fall through to a tie-break. */
+function assertVotesCast(votes: bigint[]): void {
+  if (votes.reduce((a, b) => a + b, 0n) === 0n) {
+    throw new Error('No votes cast — no winner can be declared');
+  }
 }
 
 async function main() {
@@ -85,7 +100,12 @@ async function main() {
   );
   console.log('Votes:', CANDIDATES.map((c, i) => `${c}: ${round1.votes[i]}`).join(', '));
 
-  if (!needsRunoff(round1.votes, RULES)) {
+  // Decide from the rule published in round 1's metadata, not the local
+  // constant — that published copy is what an observer can check.
+  const { rules } = (round1.meta as { runoff: { rules: RunoffRules } }).runoff;
+
+  if (!needsRunoff(round1.votes, rules)) {
+    assertVotesCast(round1.votes);
     const [top] = runoffContenders(round1.votes);
     console.log(chalk.green(`${CANDIDATES[top]} wins in round 1 (absolute majority)`));
     return;
@@ -102,9 +122,10 @@ async function main() {
     'Council presidency, round 2 ' + new Date().toISOString(),
     runoffCandidates,
     ROUND2_DISTRIBUTION,
-    { runoff: { round: 2, runoffOf: round1.electionId, contenders: [firstIdx, secondIdx], rules: RULES } }
+    { runoff: { round: 2, runoffOf: round1.electionId, contenders: [firstIdx, secondIdx], rules } }
   );
 
+  assertVotesCast(round2.votes);
   const winner = roundWinner(round2.votes);
   console.log(chalk.green(`Winner: ${runoffCandidates[winner]}`), `(${round2.votes[0]} vs ${round2.votes[1]})`);
 }

--- a/examples/typescript/src/runoff.ts
+++ b/examples/typescript/src/runoff.ts
@@ -1,44 +1,45 @@
 import chalk from 'chalk';
-import { Election, Vote } from '@vocdoni/sdk';
+import { CustomMeta, Election, PlainCensus, Vote, VocdoniSDKClient } from '@vocdoni/sdk';
+import { Wallet } from '@ethersproject/wallet';
 import { getDefaultClient, waitForElectionReady } from './utils/utils';
 import { getPlainCensus } from './utils/election-process';
+import { needsRunoff, roundWinner, runoffContenders, RunoffRules } from './utils/runoff-tally';
 
 /**
- * Example: two-round (runoff) elections built on top of the Vocdoni SDK.
+ * Example: two-round (runoff) election.
  *
- * Not a native election type — there's no single-election primitive for "if
- * nobody clears 50%, automatically hold a second round between the top two".
- * This example shows the orchestration: two ordinary native single-choice
- * elections, chained programmatically. Nothing here needs a custom tally —
- * `fetchResults()` is enough for both rounds — the missing piece is just the
- * decision logic and the second `createElection()` call.
- *
- * Real-world use: the two-round system is the most common single-winner
- * system worldwide for presidential elections — used by France (president,
- * legislature and regional elections), and at least 40 countries overall,
- * concentrated in Europe, Africa and South America. See
- * https://en.wikipedia.org/wiki/Two-round_system and
- * https://www.france24.com/en/france/20220211-explainer-how-does-france-s-two-round-presidential-election-work
+ * There is no native "hold a second round if nobody clears 50%" primitive,
+ * so this is orchestration: two ordinary native single-choice elections run
+ * by the same organiser over the same census. Each round is ended before
+ * its results are read. The runoff rule (majority denominator, tie-break)
+ * is committed to round 1's metadata; round 2's metadata points back at
+ * round 1. A round-2 vote is a fresh vote by the same electorate, not a
+ * transfer of round-1 votes.
  *
  * https://developer.vocdoni.io/protocol/ballot
  */
 
 const CANDIDATES = ['Alameda', 'Bettencourt', 'Carvalho', 'Dias'];
+const RULES: RunoffRules = { majorityThreshold: 0.5 };
 
-// deterministic distribution for this demo — nobody clears 50%, so a second
-// round between the top two (Alameda, Bettencourt) is expected
-const FIRST_ROUND_DISTRIBUTION = [5, 4, 2, 1]; // votes per candidate, in CANDIDATES order
+// Deterministic demo. Round 1: nobody clears 50%. Round 2: the same voters
+// choose between the top two.
+const ROUND1_DISTRIBUTION = [5, 4, 2, 1];
+const ROUND2_DISTRIBUTION = [7, 5];
 
-async function runSingleChoiceElection(title: string, options: string[], distribution: number[]) {
-  const totalVoters = distribution.reduce((a, b) => a + b, 0);
-  const { census, participants } = getPlainCensus(totalVoters);
-
-  const { client } = getDefaultClient();
-  await client.createAccount();
-
+async function runRound(
+  client: VocdoniSDKClient,
+  census: PlainCensus,
+  voters: Wallet[],
+  title: string,
+  options: string[],
+  distribution: number[],
+  meta: CustomMeta
+): Promise<{ electionId: string; votes: bigint[] }> {
   const endDate = new Date();
   endDate.setHours(endDate.getHours() + 10);
   const election = Election.from({ title, description: '', endDate: endDate.getTime(), census });
+  election.meta = meta;
   election.addQuestion(
     title,
     '',
@@ -53,58 +54,59 @@ async function runSingleChoiceElection(title: string, options: string[], distrib
   let voterIndex = 0;
   for (let choice = 0; choice < distribution.length; choice++) {
     for (let i = 0; i < distribution[choice]; i++) {
-      const voterClient = getDefaultClient(participants[voterIndex++]).client;
+      const voterClient = getDefaultClient(voters[voterIndex++]).client;
       voterClient.setElectionId(electionId);
       await voterClient.submitVote(new Vote([choice]));
     }
   }
 
+  // End the round before reading its results — no decision on provisional counts.
+  await client.endElection(electionId);
   const finalElection = await client.fetchElection(electionId);
-  const voteCounts = finalElection.results[0].map((count) => Number(count));
-  const total = voteCounts.reduce((a, b) => a + b, 0);
-  return { electionId, voteCounts, total };
+  return { electionId, votes: finalElection.results[0].map((count) => BigInt(count)) };
 }
 
 async function main() {
+  const voterCount = ROUND1_DISTRIBUTION.reduce((a, b) => a + b, 0);
+  const { census, participants } = getPlainCensus(voterCount);
+
+  const { client } = getDefaultClient();
+  await client.createAccount();
+
   console.log(chalk.yellow('Round 1'));
-  const round1 = await runSingleChoiceElection(
+  const round1 = await runRound(
+    client,
+    census,
+    participants,
     'Council presidency, round 1 ' + new Date().toISOString(),
     CANDIDATES,
-    FIRST_ROUND_DISTRIBUTION
+    ROUND1_DISTRIBUTION,
+    { runoff: { round: 1, rules: RULES } }
   );
-  console.log('Votes:', CANDIDATES.map((c, i) => `${c}: ${round1.voteCounts[i]}`).join(', '));
+  console.log('Votes:', CANDIDATES.map((c, i) => `${c}: ${round1.votes[i]}`).join(', '));
 
-  const leaderIndex = round1.voteCounts.reduce((best, v, i) => (v > round1.voteCounts[best] ? i : best), 0);
-  const leaderShare = round1.voteCounts[leaderIndex] / round1.total;
-
-  if (leaderShare > 0.5) {
-    console.log(chalk.green(`${CANDIDATES[leaderIndex]} wins in round 1 with ${(leaderShare * 100).toFixed(1)}%`));
+  if (!needsRunoff(round1.votes, RULES)) {
+    const [top] = runoffContenders(round1.votes);
+    console.log(chalk.green(`${CANDIDATES[top]} wins in round 1 (absolute majority)`));
     return;
   }
 
-  console.log(
-    chalk.yellow(`No absolute majority (leader ${CANDIDATES[leaderIndex]} at ${(leaderShare * 100).toFixed(1)}%) — running round 2`)
-  );
-
-  const ranked = round1.voteCounts
-    .map((votes, index) => ({ index, votes }))
-    .sort((a, b) => b.votes - a.votes);
-  const [first, second] = ranked;
-  const runoffCandidates = [CANDIDATES[first.index], CANDIDATES[second.index]];
-
+  const [firstIdx, secondIdx] = runoffContenders(round1.votes);
+  const runoffCandidates = [CANDIDATES[firstIdx], CANDIDATES[secondIdx]];
   console.log(chalk.yellow('Round 2:'), runoffCandidates.join(' vs '));
-  // second-round distribution derived from a plausible transfer of the
-  // eliminated candidates' votes — hardcoded here for a reproducible demo
-  const round2 = await runSingleChoiceElection(
+
+  const round2 = await runRound(
+    client,
+    census,
+    participants,
     'Council presidency, round 2 ' + new Date().toISOString(),
     runoffCandidates,
-    [7, 5]
+    ROUND2_DISTRIBUTION,
+    { runoff: { round: 2, runoffOf: round1.electionId, contenders: [firstIdx, secondIdx], rules: RULES } }
   );
-  const winnerIndex = round2.voteCounts[0] > round2.voteCounts[1] ? 0 : 1;
-  console.log(
-    chalk.green(`Winner: ${runoffCandidates[winnerIndex]}`),
-    `(${round2.voteCounts[0]} vs ${round2.voteCounts[1]})`
-  );
+
+  const winner = roundWinner(round2.votes);
+  console.log(chalk.green(`Winner: ${runoffCandidates[winner]}`), `(${round2.votes[0]} vs ${round2.votes[1]})`);
 }
 
 main()

--- a/examples/typescript/src/utils/runoff-tally.ts
+++ b/examples/typescript/src/utils/runoff-tally.ts
@@ -1,0 +1,52 @@
+/**
+ * Decision logic for a two-round (runoff) election.
+ *
+ * Both rounds are ordinary native single-choice elections. These helpers
+ * take the final per-candidate vote totals (`results[0]`, read after the
+ * round has ended) as bigint, so there is no rounding. The runoff rule —
+ * the majority denominator and how ties are broken — is fixed up front; in
+ * the example it is committed to the round-1 election metadata.
+ */
+
+export interface RunoffRules {
+  /**
+   * A round-1 candidate wins outright with strictly more than this fraction
+   * of the valid votes. 0.5 = absolute majority.
+   */
+  majorityThreshold: number;
+}
+
+const SCALE = 1_000_000n;
+
+/** Candidate index with the most votes; ties broken by lower index. */
+export const leader = (votes: bigint[]): number => {
+  let best = 0;
+  for (let i = 1; i < votes.length; i++) {
+    if (votes[i] > votes[best]) best = i;
+  }
+  return best;
+};
+
+/** True when no candidate clears the threshold, so a second round is held. */
+export const needsRunoff = (votes: bigint[], rules: RunoffRules): boolean => {
+  const total = votes.reduce((a, b) => a + b, 0n);
+  if (total === 0n) return false;
+  const top = votes[leader(votes)];
+  // top / total > threshold  <=>  top * SCALE > round(threshold * SCALE) * total
+  const thr = BigInt(Math.round(rules.majorityThreshold * Number(SCALE)));
+  return top * SCALE <= thr * total;
+};
+
+/**
+ * The two candidates that go through to round 2, higher total first.
+ * Ties for either place are broken by lower candidate index.
+ */
+export const runoffContenders = (votes: bigint[]): [number, number] => {
+  const order = votes
+    .map((v, index) => ({ v, index }))
+    .sort((a, b) => (a.v === b.v ? a.index - b.index : a.v < b.v ? 1 : -1));
+  return [order[0].index, order[1].index];
+};
+
+/** Winner of a two-candidate round; tie broken by lower index. */
+export const roundWinner = (votes: bigint[]): number => (votes[1] > votes[0] ? 1 : 0);

--- a/examples/typescript/src/utils/runoff-tally.ts
+++ b/examples/typescript/src/utils/runoff-tally.ts
@@ -11,12 +11,16 @@
 export interface RunoffRules {
   /**
    * A round-1 candidate wins outright with strictly more than this fraction
-   * of the valid votes. 0.5 = absolute majority.
+   * of the valid votes, given as an exact fraction: `{ num: 1, den: 2 }` is
+   * an absolute majority. A fraction (not a float) so thresholds that are
+   * not representable in binary — 1/3, 2/3 — are compared exactly.
    */
-  majorityThreshold: number;
+  majorityThreshold: { num: number; den: number };
+  /** What the threshold is measured against. */
+  denominator: 'validVotes';
+  /** How ties (for the runoff cutline, and for the round-2 winner) are broken. */
+  tieBreak: 'lowerIndex';
 }
-
-const SCALE = 1_000_000n;
 
 /** Candidate index with the most votes; ties broken by lower index. */
 export const leader = (votes: bigint[]): number => {
@@ -29,12 +33,15 @@ export const leader = (votes: bigint[]): number => {
 
 /** True when no candidate clears the threshold, so a second round is held. */
 export const needsRunoff = (votes: bigint[], rules: RunoffRules): boolean => {
+  // Empty ballot: there is no leader to index, and nobody has a majority.
+  // (An all-zero ballot needs no special case — the comparison below is
+  // 0 <= 0, so a runoff is signalled anyway.)
+  if (votes.length === 0) return true;
   const total = votes.reduce((a, b) => a + b, 0n);
-  if (total === 0n) return false;
   const top = votes[leader(votes)];
-  // top / total > threshold  <=>  top * SCALE > round(threshold * SCALE) * total
-  const thr = BigInt(Math.round(rules.majorityThreshold * Number(SCALE)));
-  return top * SCALE <= thr * total;
+  const { num, den } = rules.majorityThreshold;
+  // top / total > num / den  <=>  top * den > num * total
+  return top * BigInt(den) <= BigInt(num) * total;
 };
 
 /**
@@ -42,6 +49,7 @@ export const needsRunoff = (votes: bigint[], rules: RunoffRules): boolean => {
  * Ties for either place are broken by lower candidate index.
  */
 export const runoffContenders = (votes: bigint[]): [number, number] => {
+  if (votes.length < 2) throw new Error('A runoff needs at least two candidates');
   const order = votes
     .map((v, index) => ({ v, index }))
     .sort((a, b) => (a.v === b.v ? a.index - b.index : a.v < b.v ? 1 : -1));

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. BigInt literals (0n) require es2020+. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */

--- a/test/unit/runoff-tally.test.ts
+++ b/test/unit/runoff-tally.test.ts
@@ -1,0 +1,50 @@
+import { leader, needsRunoff, roundWinner, runoffContenders } from '../../examples/typescript/src/utils/runoff-tally';
+
+const v = (...n: number[]): bigint[] => n.map(BigInt);
+const RULES = { majorityThreshold: 0.5 };
+
+describe('Two-round (runoff) decision logic', () => {
+  it('no runoff when a candidate has an absolute majority', () => {
+    expect(needsRunoff(v(6, 3, 1), RULES)).toBe(false);
+    expect(leader(v(6, 3, 1))).toBe(0);
+  });
+
+  it('exactly half is not a majority, so a runoff is held', () => {
+    expect(needsRunoff(v(5, 3, 2), RULES)).toBe(true);
+  });
+
+  it('picks the top two contenders, higher total first', () => {
+    expect(runoffContenders(v(5, 4, 2, 1))).toEqual([0, 1]);
+  });
+
+  it('breaks a tie for second place by lower candidate index', () => {
+    expect(runoffContenders(v(5, 3, 3, 1))).toEqual([0, 1]);
+  });
+
+  it('breaks a tie for first place by lower candidate index', () => {
+    expect(runoffContenders(v(4, 4, 2))).toEqual([0, 1]);
+  });
+
+  it('round-2 winner is the plurality of the two, tie to lower index', () => {
+    expect(roundWinner(v(7, 5))).toBe(0);
+    expect(roundWinner(v(5, 7))).toBe(1);
+    expect(roundWinner(v(6, 6))).toBe(0);
+  });
+
+  it('honours a custom majority threshold', () => {
+    expect(needsRunoff(v(58, 42), { majorityThreshold: 0.6 })).toBe(true);
+    expect(needsRunoff(v(61, 39), { majorityThreshold: 0.6 })).toBe(false);
+  });
+
+  it('no votes cast means no runoff', () => {
+    expect(needsRunoff(v(0, 0, 0), RULES)).toBe(false);
+  });
+
+  it('uses exact bigint math past Number.MAX_SAFE_INTEGER', () => {
+    const a = 9007199254740993n; // 2^53 + 1 — one vote over half
+    const b = 9007199254740991n; // 2^53 - 1
+    // With Number both round to 2^53 and look tied; bigint sees a's majority.
+    expect(needsRunoff([a, b], RULES)).toBe(false);
+    expect(runoffContenders([a, b, 1n])).toEqual([0, 1]);
+  });
+});

--- a/test/unit/runoff-tally.test.ts
+++ b/test/unit/runoff-tally.test.ts
@@ -1,7 +1,11 @@
 import { leader, needsRunoff, roundWinner, runoffContenders } from '../../examples/typescript/src/utils/runoff-tally';
 
 const v = (...n: number[]): bigint[] => n.map(BigInt);
-const RULES = { majorityThreshold: 0.5 };
+const RULES = {
+  majorityThreshold: { num: 1, den: 2 },
+  denominator: 'validVotes' as const,
+  tieBreak: 'lowerIndex' as const,
+};
 
 describe('Two-round (runoff) decision logic', () => {
   it('no runoff when a candidate has an absolute majority', () => {
@@ -32,12 +36,26 @@ describe('Two-round (runoff) decision logic', () => {
   });
 
   it('honours a custom majority threshold', () => {
-    expect(needsRunoff(v(58, 42), { majorityThreshold: 0.6 })).toBe(true);
-    expect(needsRunoff(v(61, 39), { majorityThreshold: 0.6 })).toBe(false);
+    expect(needsRunoff(v(58, 42), { ...RULES, majorityThreshold: { num: 3, den: 5 } })).toBe(true);
+    expect(needsRunoff(v(61, 39), { ...RULES, majorityThreshold: { num: 3, den: 5 } })).toBe(false);
   });
 
-  it('no votes cast means no runoff', () => {
-    expect(needsRunoff(v(0, 0, 0), RULES)).toBe(false);
+  it('compares a non-binary threshold exactly: 1/3 each is not more than 1/3', () => {
+    const oneThird = { ...RULES, majorityThreshold: { num: 1, den: 3 } };
+    // Scaling 1/3 to an integer (round(1/3 * 1e6) = 333333 < 1/3) would wrongly
+    // hand this to the leader; cross-multiplication sees the exact tie.
+    expect(needsRunoff(v(1, 1, 1), oneThird)).toBe(true);
+    expect(needsRunoff(v(2, 1, 1), oneThird)).toBe(false);
+  });
+
+  it('no votes cast means a runoff is held (nobody has a majority)', () => {
+    expect(needsRunoff(v(0, 0, 0), RULES)).toBe(true);
+  });
+
+  it('an empty ballot needs a runoff and has no contenders', () => {
+    expect(needsRunoff([], RULES)).toBe(true);
+    expect(() => runoffContenders([])).toThrow('at least two candidates');
+    expect(() => runoffContenders(v(5))).toThrow('at least two candidates');
   });
 
   it('uses exact bigint math past Number.MAX_SAFE_INTEGER', () => {


### PR DESCRIPTION
## Summary

Suggestion / reference example, not a request to change core SDK behaviour.

Not a native election type — there's no single-election primitive for "if nobody clears 50%, automatically hold a second round between the top two". This example shows the orchestration instead: two ordinary native single-choice elections, chained programmatically based on the first round's `fetchResults()`. No custom tally, no raw-envelope access, no `@vocdoni/sdk` version bump needed.

## Real-world use

The two-round system is the most common single-winner system worldwide for presidential elections — used by France (president, legislature and regional elections), and at least 40 countries overall, concentrated in Europe, Africa and South America.
https://en.wikipedia.org/wiki/Two-round_system

## Testing

The majority/no-majority decision and the top-two selection are plain arithmetic on vote counts, exercised by the included (nobody-clears-50%) scenario. Network flow follows the pattern of the existing examples; not run end-to-end from my environment (STG faucet unreachable at the time of writing).