### PR TITLE
docs: add Mixed-Member Proportional (MMP) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,25 @@ More information can be found in the [documentation][approval voting documentati
 Here is a [full working example][ranked voting example] of how to create a ranked voting election.
 More information can be found in the [documentation][ranked voting documentation].
 
+#### Mixed-Member Proportional (MMP)
+
+Not a native election type — it's a composition of several *separate*
+native elections (one native single-choice election per local
+constituency, plus one native single-choice "list vote" election), with the
+compensation math (turning local wins + list proportions into final seat
+counts) computed afterwards from their aggregate results. Builds on the
+same seat-allocation helper as the D'Hondt / Sainte-Laguë example
+(./examples/typescript/src/party-list.ts). Nothing here needs raw envelope access — every piece is an
+ordinary native election. Here is a
+[full working example][mmp example].
+
+Known simplification (documented in the code, not fixed there): this
+doesn't handle "overhang" seats, where a party wins more local
+constituencies than its proportional target entitles it to. Real MMP
+systems handle this differently (Germany adds "leveling seats" for
+everyone else; New Zealand lets the chamber grow) — picking one is a policy
+decision, left to whoever adapts this example.
+
 ### Other election functionalities
 
 #### Estimate election cost
@@ -1043,6 +1062,7 @@ This SDK is licensed under the [GNU Affero General Public License v3.0][license]
 [approval voting documentation]: https://developer.vocdoni.io/protocol/ballot#multiquestion
 [ranked voting example]: ./examples/typescript/src/ranked.ts
 [ranked voting documentation]: https://developer.vocdoni.io/protocol/ballot#linear-weighted-choice
+[mmp example]: ./examples/typescript/src/mmp.ts
 [license]: ./LICENSE
 [devportal]: https://developer.vocdoni.io/sdk
 [builddocs]: ./docs/README.md

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -13,7 +13,8 @@
     "start": "ts-node src/index.ts",
     "quadratic": "ts-node src/quadratic.ts",
     "approval": "ts-node src/approval.ts",
-    "ranked": "ts-node src/ranked.ts"
+    "ranked": "ts-node src/ranked.ts",
+    "mmp": "ts-node src/mmp.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/examples/typescript/src/mmp.ts
+++ b/examples/typescript/src/mmp.ts
@@ -1,0 +1,127 @@
+import chalk from 'chalk';
+import { Election, Vote } from '@vocdoni/sdk';
+import { getDefaultClient, waitForElectionReady } from './utils/utils';
+import { getPlainCensus } from './utils/election-process';
+import { calculateMMP } from './utils/mmp-tally';
+
+/**
+ * Example: Mixed-Member Proportional (MMP) built on top of the Vocdoni SDK.
+ *
+ * Not a native election type — it's a composition of several *separate*
+ * native elections (one native single-choice election per local
+ * constituency, plus one native single-choice "list vote" election), with
+ * the compensation math (turning local wins + list proportions into final
+ * seat counts) computed afterwards from their aggregate results — see
+ * `utils/mmp-tally.ts`. Nothing here needs raw envelope access; every piece
+ * is an ordinary native election and `fetchResults()` is enough.
+ *
+ * Real-world use: MMP is used to elect the German Bundestag (since 1949)
+ * and the New Zealand House of Representatives (since 1996), and — in a
+ * regional form — the Scottish Parliament. See
+ * https://en.wikipedia.org/wiki/Mixed-member_proportional_representation
+ *
+ * https://developer.vocdoni.io/protocol/ballot
+ */
+
+const PARTIES = ['A', 'B', 'C'];
+const TOTAL_SEATS = 10;
+
+// 5 local constituencies, each a separate single-choice election — this
+// demo hardcodes who wins each one for reproducibility, matching what the
+// on-chain votes below actually produce
+const CONSTITUENCY_WINNER_VOTES = [
+  [6, 3, 1], // constituency 1: party A wins
+  [5, 4, 1], // constituency 2: party A wins
+  [2, 6, 2], // constituency 3: party B wins
+  [1, 2, 5], // constituency 4: party C wins
+  [7, 2, 1], // constituency 5: party A wins
+];
+
+// the separate "list vote" — one election, one vote per voter for a party list
+const LIST_VOTE_DISTRIBUTION = [40, 35, 25]; // votes for A, B, C
+
+async function runSingleChoiceElection(title: string, options: string[], distribution: number[]) {
+  const totalVoters = distribution.reduce((a, b) => a + b, 0);
+  const { census, participants } = getPlainCensus(totalVoters);
+
+  const { client } = getDefaultClient();
+  await client.createAccount();
+
+  const endDate = new Date();
+  endDate.setHours(endDate.getHours() + 10);
+  const election = Election.from({ title, description: '', endDate: endDate.getTime(), census });
+  election.addQuestion(
+    title,
+    '',
+    options.map((option, value) => ({ title: option, value }))
+  );
+
+  const electionId = await client.createElection(election);
+  client.setElectionId(electionId);
+  await waitForElectionReady(client, electionId);
+
+  let voterIndex = 0;
+  for (let choice = 0; choice < distribution.length; choice++) {
+    for (let i = 0; i < distribution[choice]; i++) {
+      const voterClient = getDefaultClient(participants[voterIndex++]).client;
+      voterClient.setElectionId(electionId);
+      await voterClient.submitVote(new Vote([choice]));
+    }
+  }
+
+  const finalElection = await client.fetchElection(electionId);
+  const voteCounts = finalElection.results[0].map((count) => Number(count));
+  return { electionId, voteCounts };
+}
+
+async function main() {
+  // Reference case, hand-verified: local winners [A,A,B,C,A] (A wins 3,
+  // B wins 1, C wins 1), list votes {A:40,B:35,C:25}, 10 total seats,
+  // D'Hondt. Proportional target from the list vote alone: A=4, B=4, C=2
+  // (D'Hondt quotients: 40,35,25,20,17.5,13.3,12.5,11.7,10,8.75 -> top 10
+  // are 4xA, 4xB, 2xC). Nobody's local wins exceed their target, so no
+  // overhang: compensation = target - local = A:1, B:3, C:1, giving final
+  // totals A:4, B:4, C:2, summing to exactly 10.
+  const reference = calculateMMP(['A', 'A', 'B', 'C', 'A'], { A: 40, B: 35, C: 25 }, 10, 'dhondt');
+  const referenceOk =
+    reference.perParty.A.total === 4 && reference.perParty.B.total === 4 && reference.perParty.C.total === 2;
+  if (!referenceOk) {
+    throw new Error(`MMP reference case failed: expected A:4 B:4 C:2, got ${JSON.stringify(reference.perParty)}`);
+  }
+
+  console.log(chalk.yellow(`Running ${CONSTITUENCY_WINNER_VOTES.length} local constituency elections...`));
+  const localWinners: string[] = [];
+  for (let c = 0; c < CONSTITUENCY_WINNER_VOTES.length; c++) {
+    const { voteCounts } = await runSingleChoiceElection(
+      `Constituency ${c + 1} — ${new Date().toISOString()}`,
+      PARTIES,
+      CONSTITUENCY_WINNER_VOTES[c]
+    );
+    const winnerIndex = voteCounts.reduce((best, v, i) => (v > voteCounts[best] ? i : best), 0);
+    localWinners.push(PARTIES[winnerIndex]);
+    console.log(`  constituency ${c + 1}: ${PARTIES[winnerIndex]} (${voteCounts.join('/')})`);
+  }
+
+  console.log(chalk.yellow('Running the list vote election...'));
+  const { voteCounts: listVoteCounts } = await runSingleChoiceElection(
+    'Party list vote — ' + new Date().toISOString(),
+    PARTIES,
+    LIST_VOTE_DISTRIBUTION
+  );
+  const listVotes: Record<string, number> = {};
+  PARTIES.forEach((p, i) => (listVotes[p] = listVoteCounts[i]));
+  console.log('  list votes:', JSON.stringify(listVotes));
+
+  const result = calculateMMP(localWinners, listVotes, TOTAL_SEATS, 'dhondt');
+  console.log(chalk.green('Final seats:'), JSON.stringify(result.perParty, null, 2));
+}
+
+main()
+  .then(() => {
+    console.log(chalk.green('Done ✅'));
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/examples/typescript/src/utils/mmp-tally.ts
+++ b/examples/typescript/src/utils/mmp-tally.ts
@@ -1,0 +1,51 @@
+import { allocateSeats, DivisorMethod } from './party-list-tally';
+
+/**
+ * Mixed-Member Proportional (MMP) compensation — not a native Vocdoni
+ * election type (see mmp.ts for why): it composes the results of two
+ * *separate* native elections (local single-choice constituencies + one
+ * list election) rather than being a ballot format at all.
+ *
+ * Each party's final seat count = however many local constituency seats it
+ * won, plus enough "compensation" seats from its list result to bring its
+ * total up to its proportional target (computed from the list vote via
+ * D'Hondt/Sainte-Laguë — see `party-list-tally.ts`).
+ *
+ * Known simplification (documented, not fixed here): this implementation
+ * does not handle "overhang" seats — the case where a party wins more local
+ * constituencies than its proportional target entitles it to. Real MMP
+ * systems handle this differently (Germany adds "leveling seats" to restore
+ * proportionality for everyone else; New Zealand simply lets the total
+ * chamber size grow). Picking one of those is a real policy decision, not a
+ * technical default — left to whoever adapts this example.
+ */
+
+export interface MmpResult {
+  perParty: Record<string, { local: number; target: number; compensation: number; total: number }>;
+  totalSeats: number;
+}
+
+export function calculateMMP(
+  localWinners: string[],
+  listVotes: Record<string, number>,
+  totalSeats: number,
+  method: DivisorMethod
+): MmpResult {
+  const parties = Object.keys(listVotes);
+  const votes = parties.map((p) => listVotes[p]);
+  const targets = allocateSeats(votes, totalSeats, method);
+
+  const localCounts: Record<string, number> = {};
+  parties.forEach((p) => (localCounts[p] = 0));
+  localWinners.forEach((p) => (localCounts[p] = (localCounts[p] ?? 0) + 1));
+
+  const perParty: MmpResult['perParty'] = {};
+  parties.forEach((p, i) => {
+    const local = localCounts[p] ?? 0;
+    const target = targets[i];
+    const compensation = Math.max(0, target - local);
+    perParty[p] = { local, target, compensation, total: local + compensation };
+  });
+
+  return { perParty, totalSeats: Object.values(perParty).reduce((sum, p) => sum + p.total, 0) };
+}


### PR DESCRIPTION
## Summary

Suggestion / reference example, not a request to change core SDK behaviour — last of a series of 6 (#439-#443 plus this one), all offered the same way: working examples with real-world references, for the maintainers to use however's useful.

Not a native election type — it's a composition of several *separate* native elections (one per local constituency, plus one list-vote election), with compensation math computed afterwards from their aggregate results. Reuses the seat-allocation helper from the D'Hondt / Sainte-Laguë example (#442). No raw envelope access anywhere, no `@vocdoni/sdk` version bump needed.

Documents a known simplification rather than silently deciding it: no handling for "overhang" seats (a party winning more local constituencies than its proportional target entitles it to). Real MMP systems handle this differently (Germany's leveling seats vs. New Zealand's growing chamber) — that's a policy decision I didn't think this example should make for whoever adapts it.

## Real-world use

MMP elects the German Bundestag (since 1949) and the New Zealand House of Representatives (since 1996), and — regionally — the Scottish Parliament.
https://en.wikipedia.org/wiki/Mixed-member_proportional_representation

## Testing

The compensation calculation is hand-verified against a worked example (local winners [A,A,B,C,A], list votes {A:40,B:35,C:25}, 10 seats → final A:4 B:4 C:2, summing to exactly 10, no overhang triggered in this case). Network flow follows the pattern of the existing examples; not run end-to-end from my environment (STG faucet unreachable at the time of writing).