### PR TITLE
fix(deps): force patched decode-uri-component via resolutions

### DIFF
--- a/examples/vite-react-app/package.json
+++ b/examples/vite-react-app/package.json
@@ -43,6 +43,7 @@
   },
   "resolutions": {
     "axios": "0.33.0",
+    "decode-uri-component": "0.5.0",
     "elliptic": "6.6.1",
     "ws": "7.5.11",
     "**/@walletconnect/utils/bn.js": "4.12.5"

--- a/examples/vite-react-app/yarn.lock
+++ b/examples/vite-react-app/yarn.lock
@@ -2820,10 +2820,10 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decode-uri-component@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+decode-uri-component@0.5.0, decode-uri-component@^0.2.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.5.0.tgz#4592fa1e1d640ec5e2760e2e168ad2ab5f2c9da1"
+  integrity sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==
 
 deep-is@^0.1.3:
   version "0.1.4"


### PR DESCRIPTION
This is Fable 5 speaking on behalf of elboletaire.

## Why

The **Dependabot Updates** run on `main` fails on every scheduled run with `security_update_not_possible`:

- [GHSA-vcc3-ghjq-m6fr](https://github.com/advisories/GHSA-vcc3-ghjq-m6fr) (DoS) affects `decode-uri-component <= 0.4.2`; the first patched version is **0.5.0**.
- `@walletconnect/ethereum-provider@1.8.0` → `query-string@6.13.5` pins `decode-uri-component@^0.2.0` (every query-string release up to 7.x does), so Dependabot can never bump it within semver and errors out instead.

## What

One-line `resolutions` entry in `examples/vite-react-app/package.json` forcing `decode-uri-component@0.5.0`, same pattern as the recent `fix(deps)` commits (tar/underscore/ws/axios/elliptic).

## Verification

- `yarn install` + `yarn build` pass with the forced resolution (lockfile resolves both ranges to 0.5.0).
- 0.5.0 is ESM-only while query-string@6 is CJS — inspected the built bundle: Rollup's `getAugmentedNamespace` interop wraps the ESM default export in a callable, so `require('decode-uri-component')(…)` still works.
- Only runtime consumer is the WalletConnect **v1** connector, whose bridge service shut down in 2023 — dead code in the demo regardless. Ripping WC v1 out of the example entirely would be the deeper cleanup, left out of scope here.