### PR TITLE
chore(release): v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2026-09-09
+
+### Fixed
+
+- Exported `QuadraticElection` from the public API.
+- Patched vulnerable dependencies across the whole tree: `axios`, `esbuild`,
+  `decode-uri-component`, and, via `resolutions`, `tar`, `underscore` and `ws`.
+- Patched vulnerable transitive dependencies in the `tutorial` and
+  `vite-react-app` examples.
+- Picked up the patched `circomlibjs` and `snarkjs` forks, which now resolve
+  `elliptic@6.6.1`, `bn.js@4.12.5`/`5.2.5`, `ws@7.5.13`, `tar@7.5.22` and
+  `ip-address@10.7.0`. Both forks are clear of Dependabot alerts.
+
+### Changed
+
+- Integration tests now run against a local docker stack instead of a deployed
+  server (`yarn test:integration:stack`).
+- Pinned `@eslint-community/eslint-utils` and `rollup-plugin-dts` to keep
+  node 18 support.
+
+## [0.9.3] - 2025-12-11
+
+### Added
+
+- `weight` property in `CspVote`.
+
+### Fixed
+
+- Vote weight encoding in the `cspCaBundle` method.
+
 ## [0.9.2] - 2025-02-25
 
 ## [0.9.1] - 2024-09-17

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vocdoni/sdk",
   "author": "Vocdoni",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "⚒️An SDK for building applications on top of Vocdoni API",
   "repository": "https://github.com/vocdoni/vocdoni-sdk.git",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Opus 5 here, controlled by elboletaire.

Release PR for **v0.9.4** (PATCH). Labelled `release`, so merging it will make `01_release_tagging.yml` create the `v0.9.4` tag, which then triggers `02_release_publish.yml` to publish to npm.

## Why now

Primarily dependency hygiene. The forked `circomlibjs` and `snarkjs` are both now clear of Dependabot alerts, and this cuts a release so the state is explicit and tagged. It also carries the `QuadraticElection` public API export from #437.

## Changes

- `package.json`: `0.9.3` -> `0.9.4` (the only tracked file holding the version — `src/version.ts` re-reads it from `package.json`, so `SDK_VERSION` follows automatically).
- `CHANGELOG.md`: adds the `0.9.4` entry, and backfills the missing `0.9.3` one (published to npm on 2025-12-11 with no changelog entry).

No source changes.

## Verification

Full suite run against the local docker stack (`scripts/integration-stack.sh run`), with the patched forks installed:

| suite | result |
|---|---|
| `test:unit` | 54/54 |
| `test:api` | 9/9 |
| `test:service` | 15/15 |
| `test:integration` | 36/36 |
| `test:integration:zk` | 7/7 |
| `test:census3` | 19 skipped (needs `CENSUS3_URL`, not in the local stack — pre-existing) |
| `yarn lint` / `yarn build` | clean |

The zk suite matters most here, since it is what actually exercises the two forks — poseidon via `circomlibjs` and groth16 proving via `snarkjs`. It passes in full, including the 12-participant anonymous election.

Resolved versions in this tree: `elliptic@6.6.1`, `bn.js@4.12.5`/`5.2.5`, `ws@8.21.3`, `tar@7.5.22`, `ip-address@10.7.0`, `underscore@1.13.8`.

## One caveat worth knowing

`circomlibjs` and `snarkjs` are tracked by **branch** (`#f/browser`), not by commit. So the published tarball pins nothing, and anyone on `0.9.3` already picks the fork fixes up on a fresh install without upgrading. This release makes the state explicit and tagged, but it is not the mechanism that delivers the fork patches. Pinning those two refs to commit SHAs would make delivery deterministic — happy to do that in a follow-up if wanted.